### PR TITLE
Enhancing Toggle-Active-Window-Audio.sh

### DIFF
--- a/config/hypr/scripts/Toggle-Active-Window-Audio.sh
+++ b/config/hypr/scripts/Toggle-Active-Window-Audio.sh
@@ -12,19 +12,19 @@ for ctl in "${ctlcheck[@]}"; do
   command -v "${ctl}" >/dev/null || missing+=("${ctl}")
 done
 
-if (( ${#missing[@]} )) 2>/dev/null; then
-  echo "Missing required dependencies: \"${missing[*]}\""
+if (( ${#missing[@]} )); then
+  echo "Missing required dependencies: \"${missing[*]}\"" >&2
   exit 1
 fi
 
 #// Parse .pid, .class, .title to __pid, __class, __title.
-active_json="$(hyprctl -j activewindow 2>/dev/null || { echo -e "Did hyprctl fail to run? [EXIT-CODE:-1]"; exit 1; } )"
-PID="$(jq -r '"\(.pid)\t\(.class)\t\(.title)"' <<< "${active_json}" || { echo -e "Did jq fail to run? [EXIT-CODE:-1]"; exit 1; } )"
+active_json="$(hyprctl -j activewindow 2>/dev/null)" || { echo "Did hyprctl fail to run? [EXIT-CODE:-1]" >&2; exit 1; }
+PID="$(jq -r '"\(.pid)\t\(.class)\t\(.title)"' <<< "${active_json}")" || { echo "Did jq fail to run? [EXIT-CODE:-1]" >&2; exit 1; }
 
 IFS=$'\t' read -r __pid __class __title <<< "${PID}"
 
-[[ -z "${__pid}" ]] && { echo -e "Could not resolve PID for focused window."; exit 1; }
-sink_json="$(pactl -f json list sink-inputs 2>/dev/null | iconv -f utf-8 -t utf-8 -c || { echo -e "Did pactl or iconv fail to run? Required manual intervention."; exit 1; } )"
+[[ -z "${__pid}" || "${__pid}" == "null" || "${__pid}" -le 0 ]] 2>/dev/null && { echo "Could not resolve PID for focused window." >&2; exit 1; }
+sink_json="$(pactl -f json list sink-inputs 2>/dev/null | iconv -f utf-8 -t utf-8 -c)" || { echo "Did pactl or iconv fail to run? Required manual intervention." >&2; exit 1; }
 
 #// Check if the __pid matches application.process.id or else verify other statements.
 mapfile -t sink_ids < <(jq -r --arg pid "${__pid}" --arg class "${__class}" --arg title "${__title}" '
@@ -34,33 +34,33 @@ mapfile -t sink_ids < <(jq -r --arg pid "${__pid}" --arg class "${__class}" --ar
   select(
   (.properties["application.process.id"] // "") == $pid
   or
-  (lc(.properties["application.name"]) | contains(lc($class)))
+  ($class != "" and (lc(.properties["application.name"]) | contains(lc($class))))
   or
-  (lc(.properties["application.id"]) | contains(lc($class)))
+  ($class != "" and (lc(.properties["application.id"]) | contains(lc($class))))
   or
-  (lc(.properties["application.process.binary"]) | contains(lc($class)))
+  ($class != "" and (lc(.properties["application.process.binary"]) | contains(lc($class))))
   or
-  (normalize(lc(.properties["media.name"])) | contains(normalize(lc($title))))
+  ($title != "" and (normalize(lc(.properties["media.name"])) | contains(normalize(lc($title)))))
   ) | .index' <<< "${sink_json}"
 )
 
 if [[ "${#sink_ids[@]}" -eq 0 ]]; then
   fallback_pid="$(pgrep -x "${__class}" | head -n 1 || true)"
   if [[ -n "${fallback_pid}" ]]; then
-    mapfile -t sink_ids < <( jq -r --arg pid "${fallback_pid}" '.[] | 
+    mapfile -t sink_ids < <( jq -r --arg pid "${fallback_pid}" '.[] |
       select(.properties["application.process.id"] == $pid) | .index' <<< "${sink_json}" )
   fi
 fi
 
-#// Auto-Detect if the environment is on Hyprland or $HYPRLAND_INSTANCE_SIGNATURE.
+#// Detect $HYPRLAND_INSTANCE_SIGNATURE to either parse error code or skip validation.
 if [[ ${#sink_ids[@]} -eq 0 ]]; then
   if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE}" ]]; then
     # Even if the fallback_pid remains empty, we will dispatch exit code based on $HYPRLAND_INSTANCE_SIGNATURE.
     notify-send -a "t1" -r 91190 -t 1200 -i "${swayIconDir}/volume-low.png" "No sink input for the active_window: ${__class}"
-    echo "No sink input for focused window: ${__class}"
+    echo "No sink input for focused window: ${__class}" >&2
     exit 1
   else
-    echo "No sink input for focused active_window ${__class}"
+    echo "No sink input for focused active_window ${__class}" >&2
     exit 1
   fi
 fi
@@ -83,15 +83,22 @@ else
   swayIcon="${swayIconDir}/volume-mute.png"
 fi
 
-[[ -f "${swayIcon}" ]] || echo -e "Missing swaync icons."
+[[ -f "${swayIcon}" ]] || { echo -e "Missing swaync icons." >&2; swayIcon=""; }
 
+errors=0
 for id in "${sink_ids[@]}"; do
-  pactl set-sink-input-mute "$id" "$want_mute"
+  pactl set-sink-input-mute "$id" "$want_mute" || ((++errors)) 
 done
 
-#// Append pamixer to get a nice result. Pamixer is complete optional here.
-if command -v pamixer >/dev/null; then
-  notify-send -a "t2" -r 91190 -t 800 -i "${swayIcon}" "${state_msg} ${__class}" "$(pamixer --get-default-sink | awk -F '"' 'END{print $(NF - 1)}')"
+if ((errors)); then
+  echo -e "pactl failed to set \"${id}\" to be \"${state_msg}\"! Manual intervention required." >&2
+  notify-send -a "t1" -r 91190 -t 1200 "Failed to set \"${id}\" to be \"${state_msg}\"!"
 else
-  notify-send -a "t2" -r 91190 -t 800 -i "${swayIcon}" "${state_msg} ${__class}"
+  #// Append paxmier to get a nice result. Pamixer is completely optional here.
+  if command -v pamixer >/dev/null; then
+    notify-send -a "t2" -r 91190 -t 800 -i "${swayIcon}" "${state_msg} ${__class}" "$(pamixer --get-default-sink | awk -F '"' 'END{print $(NF - 1)}')"
+  else
+    notify-send -a "t2" -r 91190 -t 800 -i "${swayIcon}" "${state_msg} ${__class}"
+  fi
 fi
+


### PR DESCRIPTION
# Pull Request
Previous Pull Request Made: #10 

## Description/Summary
Robust handling of Toggle-Active-Window-Audio.sh. Enhance the code to be full-proof while not sacrificing the readability. 

## Dependencies
- pactl
- jq
- notify-send
- awk
- pgrep
- hyprctl
- iconv

## Issues & Fixed
- Error mesages inside $(..) are captured, not displayed to the user properly.
- ${__pid} check doesn't guard against -1 or "null" from hyprctl/jq.
- Missing icon is logged but the notification still specifies the icon with -i path; also partial mute on mid-loop failure.
- Arbitrarily notification fires unconditionally even when all pactl calls fail.
 - Major: contains(lc($class)) / contains(lc($title)) silently matches all sink inputs when either argument is empty.
 
## Changes
- Robust error-codes and correctly parse values to pactl.
- Ensured that utilities used in the script has fallback. 
- 'Muted Null' or 'Unmuted Null' has been patched. While running the script without an active_window, notify-send wouldn't get executed. 
   - Prevents notify-send: 'No sink input for the active-window' unless it is under an active-window.
- Using stdout to enhance the code and show status updates without fail.

## Type of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [x] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

# Screenshots 
Screenshots may vary depending on icons!
## Muted
<img width="349" height="177" alt="Screenshot_21-Feb_15-17-57" src="https://github.com/user-attachments/assets/c95c6df9-a101-41dc-ae83-2faafe558812" />

## Unmuted
<img width="342" height="195" alt="image" src="https://github.com/user-attachments/assets/220a066a-9246-41f0-8651-138dabfca213" />

# Additional information
When muting GNOME application, they tend to have org.gnome.* because __class picks up the full name. So if we read initialTitle and then parse it to __intTitle? It tends to pick up the correct GNOME Application's name. However, mpv or firefox would have long name e.g., 'No file - mpv' or 'Mozilla Firefox' which is minor.

## Notify-Send (__class)
<img width="342" height="241" alt="image" src="https://github.com/user-attachments/assets/80b88276-3c65-468c-9de6-203318c869e9" />

## Notify-Send (__intTitle)
<img width="341" height="199" alt="image" src="https://github.com/user-attachments/assets/c3429514-a55d-4a76-a88b-c0c9c17a8078" />
<img width="346" height="194" alt="image" src="https://github.com/user-attachments/assets/4ba53758-100b-456c-90f4-2b9f875ca27f" />

```bash
PID="$(jq -r '"\(.pid)\t\(.class)\t\(.title)\t\(.initialTitle)"' <<< "${active_json}")" || { echo "Did jq fail to run? [EXIT-CODE:-1]" >&2; exit 1; }

IFS=$'\t' read -r __pid __class __title __intTitle <<< "${PID}"

....... # Line 25 -> 96

else
  # // Append paxmier to get a nice result. Pamixer is complete optional here.
  if command -v pamixer >/dev/null; then
    notify-send -a "t2" -r 91190 -i "${swayIcon}" "${state_msg} ${__intTitle}" "$(pamixer --get-default-sink | awk -F '"' 'END{print $(NF - 1)}')"
  else
    notify-send -a "t2" -r 91190 -t 800 -i "${swayIcon}" "${state_msg} ${__class}"
  fi
fi
```