### PR TITLE
Remove Wallust line from default configuration

### DIFF
--- a/config/kitty/kitty-themes/00-Default.conf
+++ b/config/kitty/kitty-themes/00-Default.conf
@@ -1,4 +1,3 @@
 # /* ---- 💫 https://github.com/LinuxBeginnings 💫 ---- */  #
 
 # This is just created to remove all the themes
-include ./01-Wallust.conf


### PR DESCRIPTION
Removed inclusion of Wallust theme configuration.

This is to remove wallust color on default.

If this line is not removed, wallust and default is no difference

Currently, if you choose default and wallust, there are no changes. 

By removing this line, there are no color as default. Only colors to appear are the config in kitty.conf
