### PR TITLE
Updated Wallpaper Selector

### DIFF
--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -66,7 +66,10 @@ mapfile -d '' PICS < <(find -L "${wallDIR}" -type f \( \
   -iname "*.mp4" -o -iname "*.mkv" -o -iname "*.mov" -o -iname "*.webm" \) -print0)
 
 RANDOM_PIC="${PICS[$((RANDOM % ${#PICS[@]}))]}"
-RANDOM_PIC_NAME=". random"
+RANDOM_PIC_NAME="$(basename "$RANDOM_PIC")"
+
+CURRENT_MON_PIC_PATH=$(swww query | grep "$focused_monitor" | awk '{print $NF}')
+CURRENT_MON_PIC_NAME=$(basename "$CURRENT_MON_PIC_PATH")
 
 # Rofi command
 rofi_command="rofi -i -show -dmenu -config $rofi_theme -theme-str $rofi_override"
@@ -74,8 +77,9 @@ rofi_command="rofi -i -show -dmenu -config $rofi_theme -theme-str $rofi_override
 # Sorting Wallpapers
 menu() {
   IFS=$'\n' sorted_options=($(sort <<<"${PICS[*]}"))
-
-  printf "%s\x00icon\x1f%s\n" "$RANDOM_PIC_NAME" "$RANDOM_PIC"
+  
+  printf "%s\x00icon\x1f%s\n" "Random: $RANDOM_PIC_NAME" "$RANDOM_PIC"
+  printf "%s\x00icon\x1f%s\n" "Current: $CURRENT_MON_PIC_NAME" "$CURRENT_MON_PIC_PATH"
 
   for pic_path in "${sorted_options[@]}"; do
     pic_name=$(basename "$pic_path")
@@ -166,6 +170,9 @@ main() {
   choice=$(echo "$choice" | xargs)
   RANDOM_PIC_NAME=$(echo "$RANDOM_PIC_NAME" | xargs)
 
+  choice="${choice#Random: }"
+  choice="${choice#Current: }"
+
   if [[ -z "$choice" ]]; then
     echo "No choice selected. Exiting."
     exit 0
@@ -176,7 +183,7 @@ main() {
     choice=$(basename "$RANDOM_PIC")
   fi
 
-  choice_basename=$(basename "$choice" | sed 's/\(.*\)\.[^.]*$/\1/')
+  choice_basename="${choice%.*}"
 
   # Search for the selected file in the wallpapers directory, including subdirectories
   selected_file=$(find "$wallDIR" -iname "$choice_basename.*" -print -quit)


### PR DESCRIPTION
# Pull Request

## Description

Wanted to add two items to the Rofi menu for the Wallpaper Selector script. Wanted to see the file name for the randomly selected file as well as see my current wallpaper that I have on the currently focused monitor. 

Updated the Random Wallpaper section in the rofi menu, it now shows "Random: {FILE_NAME}" rather than just ". Random". 

Added a menu item in the rofi menu for the Current Wallpaper, this will show the  wallpaper on the currently hovered over monitor and the file name. Menu item is listed as "Current: {FILE_NAME}". I added this to help in the case that SWWW transition does not fully complete and leaves artifacts from the previous image, now you can just select the current image to perform a refresh instead of needing to find the file by running "swww query" and searching for it in Rofi. 

Added logic to handle the naming of the two new menu items, fixed.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

<img width="1911" height="772" alt="image" src="https://github.com/user-attachments/assets/b849a590-6b78-4f7f-b5b2-4fb1bc76d208" />
