### PR TITLE
Fix kitty font style mix-up of bold and regular

### DIFF
--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -3,7 +3,7 @@
 # you can choose themes from $HOME/.config/kitty/kitty-themes/
 include ./kitty-themes/01-Wallust.conf
 
-font_family FantasqueSansM Nerd Font Mono Bold
+font_family FantasqueSansM Nerd Font Mono
 font_size 16.0
 bold_font auto
 italic_font auto


### PR DESCRIPTION
# Pull Request

## Description

This might be a small change, but with a considerable visual impact.
Until now kitty renders **all regular text as bold and vice-versa** (see screenshot below).
Comparing to the ghostty config, this was most likely an oversight and not a conscious decision.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [[CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md)](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [[commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages)](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

Below is a screenshot of the before (left) and after (right), for example "OS Age" is supposed to be bold.

<img width="2560" height="1080" alt="Screenshot_28-Mär_11-42-24_24674" src="https://github.com/user-attachments/assets/e02123be-ff71-4224-9acb-16717e736fd1" />
