### PR TITLE
Updated waybar style sheets to use `font-size: 14px`  vs.  `font-size: 99%` 

### DIFF
--- a/LUA-files/hyprland.lua
+++ b/LUA-files/hyprland.lua
@@ -1,0 +1,333 @@
+-- This is an example Hyprland Lua config file.
+-- Refer to the wiki for more information.
+-- https://wiki.hypr.land/Configuring/
+
+-- Please note not all available settings / options are set here.
+-- For a full list, see the wiki
+
+-- You can split this configuration into multiple files
+-- Create your files separately and then require them like this:
+-- require("myColors")
+
+
+------------------
+---- MONITORS ----
+------------------
+
+-- See https://wiki.hypr.land/Configuring/Monitors/
+hl.monitor({
+    output   = "",
+    mode     = "preferred",
+    position = "auto",
+    scale    = "auto",
+})
+
+
+---------------------
+---- MY PROGRAMS ----
+---------------------
+
+-- See https://wiki.hypr.land/Configuring/Keywords/
+
+-- Set programs that you use
+local terminal    = "kitty"
+local fileManager = "dolphin"
+local menu        = "hyprlauncher"
+
+
+-------------------
+---- AUTOSTART ----
+-------------------
+
+-- Autostart necessary processes (like notifications daemons, status bars, etc.)
+-- Or execute your favorite apps at launch like this:
+
+-- hl.exec_once(terminal)
+-- hl.exec_once("nm-applet")
+-- hl.exec_once("waybar & hyprpaper & firefox")
+
+
+-------------------------------
+---- ENVIRONMENT VARIABLES ----
+-------------------------------
+
+-- See https://wiki.hypr.land/Configuring/Environment-variables/
+
+hl.env("XCURSOR_SIZE", "24")
+hl.env("HYPRCURSOR_SIZE", "24")
+
+-----------------------
+---- LOOK AND FEEL ----
+-----------------------
+
+-- Refer to https://wiki.hypr.land/Configuring/Variables/
+
+-- https://wiki.hypr.land/Configuring/Variables/#general
+hl.config({
+    general = {
+        gaps_in  = 5,
+        gaps_out = 20,
+
+        border_size = 2,
+
+        -- https://wiki.hypr.land/Configuring/Variables/#variable-types for info about colors
+        col = {
+            active_border   = { colors = {"rgba(33ccffee)", "rgba(00ff99ee)", angle = 45 } },
+            inactive_border = "rgba(595959aa)",
+        },
+
+        -- Set to true to enable resizing windows by clicking and dragging on borders and gaps
+        resize_on_border = false,
+
+        -- Please see https://wiki.hypr.land/Configuring/Tearing/ before you turn this on
+        allow_tearing = false,
+
+        layout = "dwindle",
+    },
+})
+
+-- https://wiki.hypr.land/Configuring/Variables/#decoration
+hl.config({
+    decoration = {
+        rounding       = 10,
+        rounding_power = 2,
+
+        -- Change transparency of focused and unfocused windows
+        active_opacity   = 1.0,
+        inactive_opacity = 1.0,
+
+        shadow = {
+            enabled      = true,
+            range        = 4,
+            render_power = 3,
+            color        = 0xee1a1a1a,
+        },
+
+        -- https://wiki.hypr.land/Configuring/Variables/#blur
+        blur = {
+            enabled   = true,
+            size      = 3,
+            passes    = 1,
+            vibrancy  = 0.1696,
+        },
+    },
+})
+
+-- https://wiki.hypr.land/Configuring/Variables/#animations
+hl.config({
+    animations = {
+        enabled = true,
+    },
+})
+
+-- Default curves, see https://wiki.hypr.land/Configuring/Animations/#curves
+hl.curve("easeOutQuint",   { type = "bezier", points = { {0.23, 1},    {0.32, 1}    } })
+hl.curve("easeInOutCubic", { type = "bezier", points = { {0.65, 0.05}, {0.36, 1}    } })
+hl.curve("linear",         { type = "bezier", points = { {0, 0},       {1, 1}       } })
+hl.curve("almostLinear",   { type = "bezier", points = { {0.5, 0.5},   {0.75, 1}    } })
+hl.curve("quick",          { type = "bezier", points = { {0.15, 0},    {0.1, 1}     } })
+
+-- Default animations, see https://wiki.hypr.land/Configuring/Animations/
+hl.animation({ leaf = "global",        enabled = true,  speed = 10,   bezier = "default" })
+hl.animation({ leaf = "border",        enabled = true,  speed = 5.39, bezier = "easeOutQuint" })
+hl.animation({ leaf = "windows",       enabled = true,  speed = 4.79, bezier = "easeOutQuint" })
+hl.animation({ leaf = "windowsIn",     enabled = true,  speed = 4.1,  bezier = "easeOutQuint", style = "popin 87%" })
+hl.animation({ leaf = "windowsOut",    enabled = true,  speed = 1.49, bezier = "linear",       style = "popin 87%" })
+hl.animation({ leaf = "fadeIn",        enabled = true,  speed = 1.73, bezier = "almostLinear" })
+hl.animation({ leaf = "fadeOut",       enabled = true,  speed = 1.46, bezier = "almostLinear" })
+hl.animation({ leaf = "fade",          enabled = true,  speed = 3.03, bezier = "quick" })
+hl.animation({ leaf = "layers",        enabled = true,  speed = 3.81, bezier = "easeOutQuint" })
+hl.animation({ leaf = "layersIn",      enabled = true,  speed = 4,    bezier = "easeOutQuint", style = "fade" })
+hl.animation({ leaf = "layersOut",     enabled = true,  speed = 1.5,  bezier = "linear",       style = "fade" })
+hl.animation({ leaf = "fadeLayersIn",  enabled = true,  speed = 1.79, bezier = "almostLinear" })
+hl.animation({ leaf = "fadeLayersOut", enabled = true,  speed = 1.39, bezier = "almostLinear" })
+hl.animation({ leaf = "workspaces",    enabled = true,  speed = 1.94, bezier = "almostLinear", style = "fade" })
+hl.animation({ leaf = "workspacesIn",  enabled = true,  speed = 1.21, bezier = "almostLinear", style = "fade" })
+hl.animation({ leaf = "workspacesOut", enabled = true,  speed = 1.94, bezier = "almostLinear", style = "fade" })
+hl.animation({ leaf = "zoomFactor",    enabled = true,  speed = 7,    bezier = "quick" })
+
+-- Ref https://wiki.hypr.land/Configuring/Workspace-Rules/
+-- "Smart gaps" / "No gaps when only"
+-- uncomment all if you wish to use that.
+-- hl.workspace_rule({ workspace = "w[tv1]", gaps_out = 0, gaps_in = 0 })
+-- hl.workspace_rule({ workspace = "f[1]",   gaps_out = 0, gaps_in = 0 })
+-- hl.window_rule({
+--     name  = "no-gaps-wtv1",
+--     match = { float = false, workspace = "w[tv1]" },
+--     border_size = 0,
+--     rounding    = 0,
+-- })
+-- hl.window_rule({
+--     name  = "no-gaps-f1",
+--     match = { float = false, workspace = "f[1]" },
+--     border_size = 0,
+--     rounding    = 0,
+-- })
+
+-- See https://wiki.hypr.land/Configuring/Dwindle-Layout/ for more
+hl.config({
+    dwindle = {
+        pseudotile    = true,  -- Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+        preserve_split = true, -- You probably want this
+    },
+})
+
+-- See https://wiki.hypr.land/Configuring/Master-Layout/ for more
+hl.config({
+    master = {
+        new_status = "master",
+    },
+})
+
+-- See https://wiki.hypr.land/Configuring/Scrolling-Layout/ for more
+hl.config({
+    scrolling = {
+        fullscreen_on_one_column = true,
+    },
+})
+
+-- https://wiki.hypr.land/Configuring/Variables/#misc
+hl.config({
+    misc = {
+        force_default_wallpaper = -1,    -- Set to 0 or 1 to disable the anime mascot wallpapers
+        disable_hyprland_logo   = false, -- If true disables the random hyprland logo / anime girl background. :(
+    },
+})
+
+
+---------------
+---- INPUT ----
+---------------
+
+-- https://wiki.hypr.land/Configuring/Variables/#input
+hl.config({
+    input = {
+        kb_layout  = "us",
+        kb_variant = "",
+        kb_model   = "",
+        kb_options = "",
+        kb_rules   = "",
+
+        follow_mouse = 1,
+
+        sensitivity = 0, -- -1.0 - 1.0, 0 means no modification.
+
+        touchpad = {
+            natural_scroll = false,
+        },
+    },
+})
+
+-- See https://wiki.hypr.land/Configuring/Gestures/
+hl.gesture({
+    fingers = 3,
+    direction = "horizontal",
+    action = "workspace"
+})
+
+-- Example per-device config
+-- See https://wiki.hypr.land/Configuring/Keywords/#per-device-input-configs for more
+hl.device({
+    name        = "epic-mouse-v1",
+    sensitivity = -0.5,
+})
+
+
+---------------------
+---- KEYBINDINGS ----
+---------------------
+
+-- See https://wiki.hypr.land/Configuring/Keywords/
+local mainMod = "SUPER" -- Sets "Windows" key as main modifier
+
+-- Example binds, see https://wiki.hypr.land/Configuring/Binds/ for more
+hl.bind(mainMod .. " + Q", hl.exec_cmd(terminal))
+hl.bind(mainMod .. " + C", hl.window.close())
+hl.bind(mainMod .. " + M", hl.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown || hyprctl dispatch exit"))
+hl.bind(mainMod .. " + E", hl.exec_cmd(fileManager))
+hl.bind(mainMod .. " + V", hl.window.float({ action = "toggle" }))
+hl.bind(mainMod .. " + R", hl.exec_cmd(menu))
+hl.bind(mainMod .. " + P", hl.window.pseudo())
+hl.bind(mainMod .. " + J", hl.layout("togglesplit"))    -- dwindle only
+
+-- Move focus with mainMod + arrow keys
+hl.bind(mainMod .. " + left",  hl.focus({ direction = "left" }))
+hl.bind(mainMod .. " + right", hl.focus({ direction = "right" }))
+hl.bind(mainMod .. " + up",    hl.focus({ direction = "up" }))
+hl.bind(mainMod .. " + down",  hl.focus({ direction = "down" }))
+
+-- Switch workspaces with mainMod + [0-9]
+-- Move active window to a workspace with mainMod + SHIFT + [0-9]
+for i = 1, 10 do
+    local key = i % 10 -- 10 maps to key 0
+    hl.bind(mainMod .. " + " .. key,             hl.workspace(i))
+    hl.bind(mainMod .. " + SHIFT + " .. key,     hl.window.move({ workspace = i }))
+end
+
+-- Example special workspace (scratchpad)
+hl.bind(mainMod .. " + S",         hl.workspace({ special = "magic" }))
+hl.bind(mainMod .. " + SHIFT + S", hl.window.move({ workspace = "special:magic" }))
+
+-- Scroll through existing workspaces with mainMod + scroll
+hl.bind(mainMod .. " + mouse_down", hl.workspace("e+1"))
+hl.bind(mainMod .. " + mouse_up",   hl.workspace("e-1"))
+
+-- Move/resize windows with mainMod + LMB/RMB and dragging
+hl.bind(mainMod .. " + mouse:272", hl.window.drag(),   { mouse = true })
+hl.bind(mainMod .. " + mouse:273", hl.window.resize(), { mouse = true })
+
+-- Laptop multimedia keys for volume and LCD brightness
+hl.bind("XF86AudioRaiseVolume", hl.exec_cmd("wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"), { locked = true, repeating = true })
+hl.bind("XF86AudioLowerVolume", hl.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"),      { locked = true, repeating = true })
+hl.bind("XF86AudioMute",        hl.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"),     { locked = true, repeating = true })
+hl.bind("XF86AudioMicMute",     hl.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"),   { locked = true, repeating = true })
+hl.bind("XF86MonBrightnessUp",  hl.exec_cmd("brightnessctl -e4 -n2 set 5%+"),                  { locked = true, repeating = true })
+hl.bind("XF86MonBrightnessDown",hl.exec_cmd("brightnessctl -e4 -n2 set 5%-"),                  { locked = true, repeating = true })
+
+-- Requires playerctl
+hl.bind("XF86AudioNext",  hl.exec_cmd("playerctl next"),       { locked = true })
+hl.bind("XF86AudioPause", hl.exec_cmd("playerctl play-pause"), { locked = true })
+hl.bind("XF86AudioPlay",  hl.exec_cmd("playerctl play-pause"), { locked = true })
+hl.bind("XF86AudioPrev",  hl.exec_cmd("playerctl previous"),   { locked = true })
+
+
+--------------------------------
+---- WINDOWS AND WORKSPACES ----
+--------------------------------
+
+-- See https://wiki.hypr.land/Configuring/Window-Rules/ for more
+-- See https://wiki.hypr.land/Configuring/Workspace-Rules/ for workspace rules
+
+-- Example window rules that are useful
+
+hl.window_rule({
+    -- Ignore maximize requests from all apps. You'll probably like this.
+    name  = "suppress-maximize-events",
+    match = { class = ".*" },
+
+    suppress_event = "maximize",
+})
+
+hl.window_rule({
+    -- Fix some dragging issues with XWayland
+    name  = "fix-xwayland-drags",
+    match = {
+        class      = "^$",
+        title      = "^$",
+        xwayland   = true,
+        float      = true,
+        fullscreen = false,
+        pin        = false,
+    },
+
+    no_focus = true,
+})
+
+-- Hyprland-run windowrule
+hl.window_rule({
+    name  = "move-hyprland-run",
+    match = { class = "hyprland-run" },
+
+    move  = "20 monitor_h-120",
+    float = true,
+})

--- a/config/hypr/scripts/ChangeLayout.sh
+++ b/config/hypr/scripts/ChangeLayout.sh
@@ -38,7 +38,6 @@ set_layout() {
   hyprctl keyword unbind SUPER,up
   hyprctl keyword unbind SUPER,down
   hyprctl keyword unbind SUPER,O
-  hyprctl keyword unbind SUPER_SHIFT,M
 
   case "$target" in
   "dwindle")
@@ -67,7 +66,6 @@ set_layout() {
     hyprctl keyword bind SUPER,up,layoutmsg,cycleprev
     hyprctl keyword bind SUPER,right,layoutmsg,cyclenext
     hyprctl keyword bind SUPER,down,layoutmsg,cyclenext
-    hyprctl keyword bind SUPER_SHIFT,M,layoutmsg,swapnext
     notify-send -e -u low -i "$notif" " Monocle Layout"
     ;;
   "master")

--- a/config/waybar/style/0-VERTICAL-Catpuccin-Mocha.css
+++ b/config/waybar/style/0-VERTICAL-Catpuccin-Mocha.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,6 +17,8 @@
 window#waybar {
   background-color: @base;
   border-radius: 5px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 tooltip {
@@ -27,8 +30,11 @@ tooltip {
   border-color: @sapphire;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: @blue;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 #taskbar button,
@@ -224,6 +230,8 @@ tooltip label {
 window#waybar.bottombar #backlight-slider trough,
 window#waybar.bottombar #pulseaudio-slider trough {
   min-height: 7px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #backlight-slider highlight,

--- a/config/waybar/style/0-VERTICAL-Golden-Noir.css
+++ b/config/waybar/style/0-VERTICAL-Golden-Noir.css
@@ -7,6 +7,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,10 +17,14 @@ window#waybar {
     border-radius: 30px;
     color: #cba6f7;
 
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.5;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -209,6 +214,8 @@ tooltip {
 window#waybar.bottombar #backlight-slider trough,
 window#waybar.bottombar #pulseaudio-slider trough {
   min-height: 7px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #backlight-slider highlight,

--- a/config/waybar/style/0-VERTICAL-Oglo-Chicklets.css
+++ b/config/waybar/style/0-VERTICAL-Oglo-Chicklets.css
@@ -3,6 +3,7 @@
 
 * {
     font-family: "JetBrainsMono Nerd Font", FontAwesome, Roboto, Helvetica, Arial, sans-serif;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-weight: bold;
 }
@@ -13,18 +14,26 @@ window#waybar {
     color: #d3c6aa;
     transition-property: background-color;
     transition-duration: .5s;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.2;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /*
 window#waybar.empty {
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 window#waybar.solo {
     background-color: #FFFFFF;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 */
 
@@ -369,12 +378,15 @@ tooltip decoration:backdrop {
   box-shadow: none;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: #d3c6aa;
   padding-left: 5px;
   padding-right: 5px;
   padding-top: 0px;
   padding-bottom: 5px;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 
@@ -399,6 +411,8 @@ tooltip label {
 window#waybar.bottombar #backlight-slider trough,
 window#waybar.bottombar #pulseaudio-slider trough {
   min-height: 7px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #backlight-slider highlight,

--- a/config/waybar/style/Black-&-White-Monochrome.css
+++ b/config/waybar/style/Black-&-White-Monochrome.css
@@ -6,6 +6,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,6 +17,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -28,8 +31,11 @@ tooltip {
 	border-color: white;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: #cdd6f4;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 /*-----module groups----*/
 .modules-right {

--- a/config/waybar/style/Catppuccin-Frappe.css
+++ b/config/waybar/style/Catppuccin-Frappe.css
@@ -6,6 +6,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -20,10 +21,14 @@ window#waybar {
   border-bottom: 3px solid @sapphire;
   background: alpha(@crust, 0.4);
   border-radius: 10px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
   opacity: 0.2;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Catppuccin-Latte.css
+++ b/config/waybar/style/Catppuccin-Latte.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -19,10 +20,14 @@ window#waybar {
   border-bottom: 3px solid @lavender;
   background: alpha(@overlay0, 0.3);
   border-radius: 10px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
   opacity: 0.2;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Catppuccin-Mocha.css
+++ b/config/waybar/style/Catppuccin-Mocha.css
@@ -6,6 +6,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -17,10 +18,14 @@ window#waybar {
   	transition-duration: 0.5s;
   	background: transparent;
   	border-radius: 10px;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.hidden {
   	opacity: 0.2;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.empty,
@@ -28,6 +33,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Colored-Chroma-Glow.css
+++ b/config/waybar/style/Colored-Chroma-Glow.css
@@ -6,6 +6,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,10 +17,14 @@ window#waybar {
     transition-property: background-color;
     transition-duration: .5s;
     border-radius: 10px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.1;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.empty,
@@ -27,6 +32,8 @@ window#waybar.empty #window {
     padding: 0px;
     border: 0px;
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -39,8 +46,11 @@ tooltip {
     border-color: #11111b;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
     color: #cdd6f4;
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Colored-Translucent.css
+++ b/config/waybar/style/Colored-Translucent.css
@@ -20,6 +20,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -30,10 +31,14 @@ window#waybar {
     transition-property: background-color;
     transition-duration: .5s;
     border-radius: 10px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.1;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Colorful-Aurora-Blossom.css
+++ b/config/waybar/style/Colorful-Aurora-Blossom.css
@@ -5,12 +5,15 @@
 	font-family: "JetBrainsMono Nerd Font";
 	font-weight: bold;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
 
 window#waybar {
 	background: transparent;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.empty ,
@@ -18,6 +21,8 @@ window#waybar.empty #window {
 	background-color: transparent;
     padding: 0px;
     border: 0px;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {
@@ -27,8 +32,11 @@ tooltip {
 	border-radius: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: black;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 
 /*-----module groups----*/

--- a/config/waybar/style/Colorful-Aurora.css
+++ b/config/waybar/style/Colorful-Aurora.css
@@ -5,6 +5,7 @@
 font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -15,6 +16,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -24,8 +27,11 @@ tooltip {
 	border-radius: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: black;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 /*-----module groups----*/
 .modules-left,

--- a/config/waybar/style/Colorful-Oglo-Chicklets.css
+++ b/config/waybar/style/Colorful-Oglo-Chicklets.css
@@ -3,6 +3,7 @@
 
 * {
     font-family: "JetBrainsMono Nerd Font", FontAwesome, Roboto, Helvetica, Arial, sans-serif;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-weight: bold;
 }
@@ -13,18 +14,26 @@ window#waybar {
     color: #d3c6aa;
     transition-property: background-color;
     transition-duration: .5s;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.2;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /*
 window#waybar.empty {
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 window#waybar.solo {
     background-color: #FFFFFF;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 */
 
@@ -369,12 +378,15 @@ tooltip decoration:backdrop {
   box-shadow: none;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: #d3c6aa;
   padding-left: 5px;
   padding-right: 5px;
   padding-top: 0px;
   padding-bottom: 5px;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 

--- a/config/waybar/style/Colorful-Rainbow-Spectrum.css
+++ b/config/waybar/style/Colorful-Rainbow-Spectrum.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -14,10 +15,14 @@ window#waybar {
   	background-color: rgba(0,0,0,0);
   	transition-property: background-color;
   	transition-duration: .5s;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.hidden {
   	opacity: 0.5;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.empty,
@@ -25,6 +30,8 @@ window#waybar.empty #window {
 	padding: 0px;
 	border: 0px;
 	background-color: transparent;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {
@@ -36,8 +43,11 @@ tooltip {
 	border-color: #11111b;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: #cdd6f4;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Colorful-stolen-style.css
+++ b/config/waybar/style/Colorful-stolen-style.css
@@ -5,6 +5,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -14,10 +15,14 @@ window#waybar {
   transition-duration: 0.5s;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 6px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
   opacity: 0.2;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.empty,
@@ -25,6 +30,8 @@ window#waybar.empty #window {
   background-color: rgba(0, 0, 0, 0.8);
   padding: 0px;
   border: 0px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #backlight,
@@ -288,6 +295,7 @@ window#waybar.empty #window {
 }
 
 #window {
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 100%;
   color: #ffffed;
 }

--- a/config/waybar/style/Crystal-Clear-Glass.css
+++ b/config/waybar/style/Crystal-Clear-Glass.css
@@ -19,6 +19,7 @@ General
   /* Extra tweaks */
   min-height: 0;
   /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 99%;
   font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
   margin-top: 3px;
@@ -27,6 +28,8 @@ General
 
 window#waybar {
   background: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 .modules-left {
@@ -134,6 +137,8 @@ tooltip {
 
 window#waybar.empty #window {
   background-color: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 /* -----------------------------------------------------

--- a/config/waybar/style/Dark-Golden-Eclipse.css
+++ b/config/waybar/style/Dark-Golden-Eclipse.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 padding: 1px;
@@ -21,10 +22,14 @@ window#waybar {
 	padding-right: 4px;
 	padding-left: 4px;
 	border-radius: 12px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
   opacity: 0.2;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #waybar.empty #window {

--- a/config/waybar/style/Dark-Golden-Noir.css
+++ b/config/waybar/style/Dark-Golden-Noir.css
@@ -7,6 +7,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,10 +17,14 @@ window#waybar {
     border-radius: 30px;
     color: #cba6f7;
 
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.5;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Dark-Half-Moon.css
+++ b/config/waybar/style/Dark-Half-Moon.css
@@ -8,6 +8,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -18,6 +19,8 @@ window#waybar {
   border-bottom: 1px solid rgba(26,27,38,0);
   border-radius: 0px;
   color: #E6B673;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #waybar.empty, #waybar.tiled, #waybar.floating {
@@ -27,6 +30,8 @@ window#waybar {
 window#waybar.empty,
 window#waybar.empty #window {
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar,
@@ -100,8 +105,11 @@ border: 1px solid #D2A6FF;
 border-radius: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
 color: #F3F4F5;
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+font-size: 14px;
 }
 
 #window {

--- a/config/waybar/style/Dark-Latte-Wallust-combined-v2.css
+++ b/config/waybar/style/Dark-Latte-Wallust-combined-v2.css
@@ -25,6 +25,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -36,6 +37,8 @@ window#waybar {
 	padding-bottom: 0px;
 	padding-right: 4px;
 	padding-left: 4px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Dark-Latte-Wallust-combined.css
+++ b/config/waybar/style/Dark-Latte-Wallust-combined.css
@@ -25,6 +25,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -33,10 +34,14 @@ window#waybar {
     background: transparent;
     border-radius: 0px;
     color: #cba6f7;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Dark-Purpl.css
+++ b/config/waybar/style/Dark-Purpl.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;		
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -14,10 +15,14 @@
 window#waybar {
 	background: #100214;
 	color: #cba6f7;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Dark-Wallust-Obsidian-Edge.css
+++ b/config/waybar/style/Dark-Wallust-Obsidian-Edge.css
@@ -8,6 +8,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -15,10 +16,14 @@ font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 window#waybar {
     background: black;
 	border-radius: 12px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.5;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -27,10 +32,13 @@ tooltip {
     border-radius: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
     color: @foreground;
     padding-right: 2px;
     padding-left: 2px;
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 /*-----module groups----*/

--- a/config/waybar/style/Extra-Arrow.css
+++ b/config/waybar/style/Extra-Arrow.css
@@ -7,6 +7,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
     border: none;

--- a/config/waybar/style/Extra-Crimson.css
+++ b/config/waybar/style/Extra-Crimson.css
@@ -6,6 +6,7 @@
 font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -15,10 +16,14 @@ window#waybar {
 	color: wheat;
 	border-radius: 0px 0px 100px 100px;
 	border: 1px solid grey;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 	
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 } 
 
 tooltip {

--- a/config/waybar/style/Extra-EverForest.css
+++ b/config/waybar/style/Extra-EverForest.css
@@ -33,6 +33,7 @@
   font-weight: bold;
   min-height: 0;
   /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 99%;
   font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
   border: 1px solid transparent;
@@ -47,10 +48,14 @@ window#waybar {
   color: @fg;
   transition-property: background-color;
   transition-duration: 0.5s;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 #window {

--- a/config/waybar/style/Extra-ML4W-starter.css
+++ b/config/waybar/style/Extra-ML4W-starter.css
@@ -22,6 +22,7 @@
     border-radius: 4px;
     font-weight: bold;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -32,6 +33,8 @@ window#waybar {
     /* color: #FFFFFF; */
     transition-property: background-color;
     transition-duration: .5s;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* -----------------------------------------------------
@@ -86,8 +89,11 @@ tooltip {
     margin:0px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
     color: @textcolor2;
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* -----------------------------------------------------
@@ -105,6 +111,8 @@ tooltip label {
 
 window#waybar.empty #window {
     background-color:transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* -----------------------------------------------------

--- a/config/waybar/style/Extra-Mauve.css
+++ b/config/waybar/style/Extra-Mauve.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;		
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -14,10 +15,14 @@
 window#waybar {
 	background: #11111b;
 	color: #cba6f7;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Extra-Modern-Combined-Transparent.css
+++ b/config/waybar/style/Extra-Modern-Combined-Transparent.css
@@ -38,6 +38,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -49,6 +50,8 @@ window#waybar {
 	padding-bottom: 0px;
 	padding-right: 4px;
 	padding-left: 4px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Extra-Modern-Combined.css
+++ b/config/waybar/style/Extra-Modern-Combined.css
@@ -38,6 +38,7 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -49,6 +50,8 @@ window#waybar {
 	padding-bottom: 0px;
 	padding-right: 4px;
 	padding-left: 4px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Extra-Neon-Circuit.css
+++ b/config/waybar/style/Extra-Neon-Circuit.css
@@ -16,12 +16,15 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
 
 window#waybar {
     background: @bar-bg;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Extra-Prismatic-Glow.css
+++ b/config/waybar/style/Extra-Prismatic-Glow.css
@@ -6,11 +6,13 @@
     font-weight: bold;
 	min-height: 0;  
     /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
     
     border: none;
     border-radius: 10px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     min-height: 20px;
     margin: 0px;
@@ -20,6 +22,7 @@
 .module {
     padding: 2px 4px;
     margin: 1px 1px;
+    /* Waybar scaling: adjust font-size to scale the bar */
     font-size: 14px;
 }
 
@@ -36,6 +39,7 @@
 window#waybar {
     background-color: transparent;
     color: black;
+    /* Waybar scaling: adjust font-size to scale the bar */
     font-size: 14px;
     transition: background-color 0.5s;
 }
@@ -44,10 +48,14 @@ window#waybar {
 window#waybar.empty #window {
     background-color: transparent;
     background: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.hidden {
     opacity: 0.2;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* Tooltip styling */
@@ -62,8 +70,11 @@ tooltip {
 }
 
 menu label,
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
     color: rgb(0, 238, 255);
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* Workspaces Button Styling */
@@ -128,6 +139,8 @@ tooltip label {
 #taskbar.empty,
 window#waybar.empty {
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 /* Specific Module Styles */

--- a/config/waybar/style/Extra-Prismatic-Glow.css
+++ b/config/waybar/style/Extra-Prismatic-Glow.css
@@ -20,6 +20,7 @@
 .module {
     padding: 2px 4px;
     margin: 1px 1px;
+    font-size: 14px;
 }
 
 .modules-left>widget:first-child .module {
@@ -35,6 +36,7 @@
 window#waybar {
     background-color: transparent;
     color: black;
+    font-size: 14px;
     transition: background-color 0.5s;
 }
 

--- a/config/waybar/style/Extra-Rose-Pine.css
+++ b/config/waybar/style/Extra-Rose-Pine.css
@@ -14,6 +14,7 @@
 	font-family: "JetBrainsMono Nerd Font";
 	font-weight: bold;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 	border-radius: 12px;
@@ -21,6 +22,8 @@
 
 window#waybar {
     background: @bar-bg;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.empty,
@@ -28,6 +31,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Extra-Simple-Pink.css
+++ b/config/waybar/style/Extra-Simple-Pink.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;	
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -15,10 +16,14 @@ window#waybar {
 	background: black;
 	border-radius: 50px;
 	color: whitesmoke;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Light-Monochrome-Contrast.css
+++ b/config/waybar/style/Light-Monochrome-Contrast.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,6 +17,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {
@@ -28,8 +31,11 @@ tooltip {
 	border-color: white;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: #cdd6f4;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 /*-----module groups----*/
 .modules-left,

--- a/config/waybar/style/Light-Obsidian-Glow.css
+++ b/config/waybar/style/Light-Obsidian-Glow.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -13,10 +14,14 @@ font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 window#waybar {
 	background: white;
 	border-radius: 12px;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.7;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {
@@ -24,10 +29,13 @@ tooltip {
 	border-radius: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
 	color: #373737;
 	padding-right: 2px;
 	padding-left: 2px;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/ML4W-Glass-3d.css
+++ b/config/waybar/style/ML4W-Glass-3d.css
@@ -19,6 +19,7 @@ General
   /* Extra tweaks */
   min-height: 0;
   /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 99%;
   font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
   margin-top: 3px;
@@ -45,6 +46,8 @@ window#waybar {
   background: transparent;
   border: 0;
   outline: none;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 .modules-left {
@@ -184,8 +187,11 @@ tooltip {
   margin: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: @on_surface;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 /* -----------------------------------------------------
@@ -201,6 +207,8 @@ tooltip label {
 
 window#waybar.empty #window {
   background-color: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 /* Tighter content padding specifically for the window title */

--- a/config/waybar/style/ML4W-Glass.css
+++ b/config/waybar/style/ML4W-Glass.css
@@ -19,6 +19,7 @@ General
   /* Extra tweaks */
   min-height: 0;
   /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 99%;
   font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
   margin-top: 3px;
@@ -40,6 +41,8 @@ General
 
 window#waybar {
   background: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 .modules-left {
@@ -173,8 +176,11 @@ tooltip {
   margin: 10px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: @on_surface;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 /* -----------------------------------------------------
@@ -187,6 +193,8 @@ tooltip label {
 
 window#waybar.empty #window {
   background-color: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 /* -----------------------------------------------------

--- a/config/waybar/style/Rainbow-RGB-Bordered.css
+++ b/config/waybar/style/Rainbow-RGB-Bordered.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -18,10 +19,14 @@ window#waybar {
   	transition-duration: 0.5s;
   	background: transparent;
   	border-radius: 2px;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.hidden {
   	opacity: 0.2;
+  	/* Waybar scaling: adjust font-size to scale the bar */
+  	font-size: 14px;
 }
 
 window#waybar.empty,
@@ -29,6 +34,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Retro-Simple-Style.css
+++ b/config/waybar/style/Retro-Simple-Style.css
@@ -13,6 +13,7 @@
 	font-weight: bold;
 	min-height: 0;	
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 
@@ -23,6 +24,8 @@ window#waybar {
   color: @foreground;
   transition-property: background-color;
   transition-duration: 0.5s;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Transparent-Crystal-Clear.css
+++ b/config/waybar/style/Transparent-Crystal-Clear.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;	
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -15,10 +16,14 @@ window#waybar {
 	background:transparent;
 	border-radius: 1px;
 	color: whitesmoke;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 	
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.empty	
@@ -26,6 +31,8 @@ window#waybar.empty #window {
    padding: 0px;
    border: 0px;
    background-color: transparent;
+   /* Waybar scaling: adjust font-size to scale the bar */
+   font-size: 14px;
 }
 
 #taskbar button,	   

--- a/config/waybar/style/VERTICAL-Catpuccin-Mocha.css
+++ b/config/waybar/style/VERTICAL-Catpuccin-Mocha.css
@@ -7,6 +7,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -16,6 +17,8 @@
 window#waybar {
   background-color: @base;
   border-radius: 5px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 tooltip {
@@ -27,8 +30,11 @@ tooltip {
   border-color: @sapphire;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
   color: @blue;
+  /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+  font-size: 14px;
 }
 
 #taskbar button,
@@ -227,6 +233,8 @@ tooltip label {
 window#waybar.bottombar #backlight-slider trough,
 window#waybar.bottombar #pulseaudio-slider trough {
   min-height: 7px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #backlight-slider highlight,

--- a/config/waybar/style/Wallust-Bordered-Chroma-Fusion-Edge.css
+++ b/config/waybar/style/Wallust-Bordered-Chroma-Fusion-Edge.css
@@ -25,6 +25,7 @@
 	font-weight: bold;
 	min-height: 0;	
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -38,6 +39,8 @@ window#waybar {
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
     border:2px solid black;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.empty,
@@ -45,6 +48,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Wallust-Bordered-Chroma-Simple.css
+++ b/config/waybar/style/Wallust-Bordered-Chroma-Simple.css
@@ -8,6 +8,7 @@
 	font-family: "JetBrainsMono Nerd Font";
 	font-weight: bold;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
     min-height: 0;
 }
@@ -25,6 +26,8 @@ window#waybar {
     color: @foreground;
     padding-left: 15px;
     padding-right: 15px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar.empty,
@@ -32,6 +35,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Wallust-Box-type.css
+++ b/config/waybar/style/Wallust-Box-type.css
@@ -8,16 +8,21 @@
   font-weight: bold;
   min-height: 0;
   /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+  /* NOTE: Waybar v14+ ignores % font-size values */
   font-size: 99%;
   font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
 
 window#waybar {
   background: transparent;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.hidden {
   opacity: 0.2;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 window#waybar.empty,
@@ -25,6 +30,8 @@ window#waybar.empty #window {
   background-color: transparent;
   padding: 0px;
   border: 0px;
+  /* Waybar scaling: adjust font-size to scale the bar */
+  font-size: 14px;
 }
 
 #window {

--- a/config/waybar/style/Wallust-Chroma-Edge.css
+++ b/config/waybar/style/Wallust-Chroma-Edge.css
@@ -8,6 +8,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -21,6 +22,8 @@ window#waybar {
 	/* border-top: 8px transparent; */
 	border-radius: 0px;
 	transition-duration: 0.5s;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.empty
@@ -28,10 +31,14 @@ window#waybar.empty #window {
 	padding: 0px;
 	border: 0px;
 	background-color: transparent;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.hidden {
 	opacity: 0.1;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 tooltip {
@@ -43,8 +50,11 @@ tooltip {
 	border-color: @color12;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label{
 	color: #cdd6f4;
+	/* Waybar scaling: adjust tooltip label font-size to scale the bar */
+	font-size: 14px;
 }
 
 #taskbar button,

--- a/config/waybar/style/Wallust-Chroma-Fusion.css
+++ b/config/waybar/style/Wallust-Chroma-Fusion.css
@@ -25,6 +25,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -37,6 +38,8 @@ window#waybar {
     border-bottom-left-radius: 20px;
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 
 window#waybar.empty,
@@ -44,6 +47,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Wallust-Chroma-Tally-V2.css
+++ b/config/waybar/style/Wallust-Chroma-Tally-V2.css
@@ -9,6 +9,7 @@
     font-family: "JetBrainsMono Nerd Font";
     font-weight: bold;
     min-height: 0;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 99%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -19,6 +20,8 @@ window#waybar {
     border-bottom: 2px;
     border-style: solid;
     border-color: @color7; /* Light border */
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #workspaces {

--- a/config/waybar/style/Wallust-Chroma-Tally.css
+++ b/config/waybar/style/Wallust-Chroma-Tally.css
@@ -8,6 +8,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -18,6 +19,8 @@ window#waybar {
 	border-bottom: 2px;
     border-style: solid;
 	border-color: @color12; 
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #workspaces {

--- a/config/waybar/style/Wallust-Colored.css
+++ b/config/waybar/style/Wallust-Colored.css
@@ -8,12 +8,15 @@
     font-weight: bold;
 	min-height: 0;	
      /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 96%;
     font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
 
 window#waybar.hidden {
     opacity: 0.5;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 window#waybar,
@@ -21,6 +24,8 @@ window#waybar.empty #window {
     padding: 0px;
     border: 0px;
     background-color: transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 

--- a/config/waybar/style/Wallust-ML4W-modern-mixed.css
+++ b/config/waybar/style/Wallust-ML4W-modern-mixed.css
@@ -18,6 +18,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	/* note: different modules have different font sizes */
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
@@ -30,6 +31,8 @@ border-bottom: 0px solid @foreground;
     background: transparent;
     transition-property: background-color;
     transition-duration: .5s;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar,
@@ -83,8 +86,11 @@ tooltip {
     margin:0px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
     color: @textcolor2;
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 #window {
@@ -98,6 +104,8 @@ tooltip label {
 
 window#waybar.empty #window {
     background-color:transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar.empty {
@@ -179,6 +187,7 @@ window#waybar.empty #window {
 	padding: 2px;
     margin-right: 8px;
 	margin-left: 6px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 100%;
     opacity: 0.8;
     color: @iconcolor;
@@ -190,6 +199,7 @@ window#waybar.empty #window {
 
 #idle_inhibitor {
     margin-right: 15px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 102%;
     font-weight: bold;
     opacity: 0.8;
@@ -199,6 +209,7 @@ window#waybar.empty #window {
 
 #idle_inhibitor.activated {
     margin-right: 15px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 100%;
     font-weight: bold;
     opacity: 0.8;

--- a/config/waybar/style/Wallust-ML4W-modern.css
+++ b/config/waybar/style/Wallust-ML4W-modern.css
@@ -18,6 +18,7 @@
 	font-weight: bold;
 	min-height: 0;
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	/* note: different modules have different font sizes */
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
@@ -30,6 +31,8 @@ border-bottom: 0px solid @foreground;
     background: transparent;
     transition-property: background-color;
     transition-duration: .5s;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #workspaces {
@@ -75,8 +78,11 @@ tooltip {
     margin:0px;
 }
 
+/* Waybar scaling: adjust tooltip label font-size to scale the bar */
 tooltip label {
     color: @textcolor2;
+    /* Waybar scaling: adjust tooltip label font-size to scale the bar */
+    font-size: 14px;
 }
 
 #window {
@@ -89,6 +95,8 @@ tooltip label {
 
 window#waybar.empty #window {
     background-color:transparent;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 #taskbar {
@@ -185,6 +193,7 @@ window#waybar.empty #window {
 #custom-weather.sunnyDay {
     margin-right: 8px;
 	margin-left: 6px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 100%;
     color: @iconcolor;
 }
@@ -195,6 +204,7 @@ window#waybar.empty #window {
 
 #idle_inhibitor {
     margin-right: 15px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 102%;
     font-weight: bold;
     color: @iconcolor;
@@ -203,6 +213,7 @@ window#waybar.empty #window {
 
 #idle_inhibitor.activated {
     margin-right: 15px;
+    /* NOTE: Waybar v14+ ignores % font-size values */
     font-size: 100%;
     font-weight: bold;
 color: @color13;

--- a/config/waybar/style/Wallust-Simple.css
+++ b/config/waybar/style/Wallust-Simple.css
@@ -6,6 +6,7 @@ font-family: "JetBrainsMono Nerd Font";
 font-weight: bold;
 min-height: 0;
 /* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+/* NOTE: Waybar v14+ ignores % font-size values */
 font-size: 99%;
 font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -22,6 +23,8 @@ window#waybar.empty #window {
     background-color: transparent;
     padding: 0px;
     border: 0px;
+    /* Waybar scaling: adjust font-size to scale the bar */
+    font-size: 14px;
 }
 
 tooltip {

--- a/config/waybar/style/Wallust-Transparent-Crystal-Clear.css
+++ b/config/waybar/style/Wallust-Transparent-Crystal-Clear.css
@@ -15,6 +15,7 @@
 	font-weight: bold;
 	min-height: 0;	
 	/* set font-size to 100% if font scaling is set to 1.00 using nwg-look */
+	/* NOTE: Waybar v14+ ignores % font-size values */
 	font-size: 99%;
 	font-feature-settings: '"zero", "ss01", "ss02", "ss03", "ss04", "ss05", "cv31"';
 }
@@ -23,19 +24,27 @@ window#waybar {
 	background:transparent;
 	border-radius: 1px;
 	color: @text;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 	
 window#waybar.hidden {
 	opacity: 0.5;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 window#waybar.empty {
 	background-color: transparent;
+	/* Waybar scaling: adjust font-size to scale the bar */
+	font-size: 14px;
 }
 	
 window#waybar.empty #window {
    padding: 0px;
    border: 0px;
    background-color: transparent;
+   /* Waybar scaling: adjust font-size to scale the bar */
+   font-size: 14px;
 } 
 
 /*-----module groups----*/


### PR DESCRIPTION
# Pull Request

## Description

Waybar versions 14+ no longer support  font-size: 99% 

```toml
window#waybar {
  font-size: 14px;
}

.module,
#workspaces button,
#taskbar button,
#tray,
tooltip label {
  font-size: 14px;
}
```


## Type of change


- [X] **Bug fix** (non-breaking change which fixes an issue)
 