### PR TITLE
Removed obsolete sed patterns from WallpaperSelect.sh

### DIFF
--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -135,7 +135,6 @@ modify_startup_config() {
   if [[ "$selected_file" =~ \.(mp4|mkv|mov|webm)$ ]]; then
     # For video wallpapers:
     sed -i '/^\s*exec-once\s*=\s*\$scriptsDir\/WallpaperDaemon\.sh\s*$/s/^/\#/' "$startup_config"
-    sed -i '/^\s*exec-once\s*=\s*swww-daemon\s*--format\s*xrgb\s*$/s/^/\#/' "$startup_config"
     sed -i '/^\s*#\s*exec-once\s*=\s*mpvpaper\s*.*$/s/^#\s*//;' "$startup_config"
 
     # Update the livewallpaper variable with the selected video path (using $HOME)
@@ -146,7 +145,6 @@ modify_startup_config() {
   else
     # For image wallpapers:
     sed -i '/^\s*#\s*exec-once\s*=\s*\$scriptsDir\/WallpaperDaemon\.sh\s*$/s/^\s*#\s*//;' "$startup_config"
-    sed -i '/^\s*#\s*exec-once\s*=\s*swww-daemon\s*--format\s*xrgb\s*$/s/^\s*#\s*//;' "$startup_config"
 
     sed -i '/^\s*exec-once\s*=\s*mpvpaper\s*.*$/s/^/\#/' "$startup_config"
 


### PR DESCRIPTION
Removes old sed commands in WallpaperSelect.sh that target a legacy swww-daemon line in Startup_Apps.conf. 

Since wallpaper initialization is now handled by WallpaperDaemon.sh, these patterns no longer match and can be safely removed to clean up the script. 

Testing confirms that switching between static images and video wallpapers still works as expected.