### PR TITLE
Add Kitty terminal link handler with Hyprland browser focus

### DIFF
--- a/config/hypr/scripts/open-url-hypr.sh
+++ b/config/hypr/scripts/open-url-hypr.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${1:?URL required}"
+
+# Open in an existing Firefox tab when possible.
+if pgrep -x firefox >/dev/null 2>&1; then
+  firefox --new-tab "$url" >/dev/null 2>&1 &
+else
+  xdg-open "$url" >/dev/null 2>&1 &
+fi
+
+if ! command -v hyprctl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+browser_re='^(org\.mozilla\.firefox|firefox|Google-chrome|chromium|Brave-browser|zen|Microsoft-edge)$'
+
+for _ in $(seq 1 50); do
+  read -r addr ws_id <<< "$(hyprctl clients -j | jq -r --arg re "$browser_re" '
+    [.[] | select(.class | test($re; "i"))][0] // empty
+    | "\(.address) \(.workspace.id)"
+  ')"
+
+  if [ -n "${addr:-}" ] && [ "$addr" != "null" ]; then
+    hyprctl dispatch workspace "$ws_id" >/dev/null
+    hyprctl dispatch focuswindow "address:$addr" >/dev/null
+    hyprctl dispatch bringactivetotop >/dev/null 2>&1 || true
+    exit 0
+  fi
+
+  sleep 0.1
+done

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -30,4 +30,13 @@ window_padding_width 4
 selection_foreground none
 selection_background none
 
+# Open links in browser and jump to its Hyprland workspace
+url_style curly
+url_color #7dcfff
+open_url_with ${HOME}/.local/bin/open-url-hypr
+
+# Ctrl+click OR Ctrl+Shift+click on a URL / hyperlink
+mouse_map ctrl+left click ungrabbed mouse_handle_click link
+mouse_map ctrl+shift+left click ungrabbed mouse_handle_click link
+
 # foreground/background/cursor are set by the active theme

--- a/config/kitty/open-actions.conf
+++ b/config/kitty/open-actions.conf
@@ -1,0 +1,5 @@
+protocol https
+action launch --type=background ${HOME}/.local/bin/open-url-hypr $URL
+
+protocol http
+action launch --type=background ${HOME}/.local/bin/open-url-hypr $URL

--- a/scripts/lib_apps.sh
+++ b/scripts/lib_apps.sh
@@ -104,6 +104,15 @@ install_terminal_configs() {
   else
     echo "${ERROR:-[ERROR]} - $WEZTERM_SRC not found; skipping WezTerm config install." 2>&1 | tee -a "$log"
   fi
+
+  # Kitty: open terminal URLs in the browser and focus it in Hyprland
+  local OPEN_URL_SRC="$base/config/hypr/scripts/open-url-hypr.sh"
+  local OPEN_URL_DEST="$HOME/.local/bin/open-url-hypr"
+  if [ -f "$OPEN_URL_SRC" ]; then
+    mkdir -p "$HOME/.local/bin"
+    install -m 0755 "$OPEN_URL_SRC" "$OPEN_URL_DEST" 2>&1 | tee -a "$log"
+    echo "${OK:-[OK]} - Installed Kitty URL helper to $OPEN_URL_DEST." 2>&1 | tee -a "$log"
+  fi
 }
 
 choose_default_editor() {


### PR DESCRIPTION
## Summary
- Add `open-url-hypr.sh` to open terminal URLs in the browser and switch Hyprland to the browser workspace
- Configure Kitty `Ctrl+click` and `Ctrl+Shift+click` link handling via `kitty.conf` and `open-actions.conf`
- Install the helper to `~/.local/bin` during dotfiles setup

## Test plan
- [x] Paste `echo 'https://example.com'` in Kitty on workspace 2
- [x] Ctrl+click opens Firefox on workspace 1 and focuses it


Made with [Cursor](https://cursor.com)