### PR TITLE
Fix: ExternalBrightness.sh fails to parse ddcutil getvcp output

### DIFF
--- a/config/hypr/scripts/ExternalBrightness.sh
+++ b/config/hypr/scripts/ExternalBrightness.sh
@@ -37,8 +37,8 @@ get_brightness() {
     return 1
   fi
   local current max
-  current="$(printf "%s" "${line}" | sed -n 's/.*current value = \([0-9]\+\).*/\1/p')"
-  max="$(printf "%s" "${line}" | sed -n 's/.*max value = \([0-9]\+\).*/\1/p')"
+  current="$(printf "%s" "${line}" | sed -n 's/.*current value = *\([0-9]\+\).*/\1/p')"
+  max="$(printf "%s" "${line}" | sed -n 's/.*max value = *\([0-9]\+\).*/\1/p')"
   [[ -n "${current}" && -n "${max}" ]] || return 1
   printf "%s %s\n" "${current}" "${max}"
 }


### PR DESCRIPTION
## Problem

On my setup, ExternalBrightness.sh always reports N/A. The brightness value is
never parsed from the ddcutil getvcp output, so the custom/brightness_external
module shows N/A and does not respond to scroll.

## Root cause

The parsing regex expects exactly one space after "current value =":

    sed -n 's/.*current value = \([0-9]\+\).*/\1/p'

ddcutil right-justifies the value in a fixed-width field. The format string in
the ddcutil source (src/vcp/vcp_feature_codes.c) is:

    "current value = %5d, max value = %5d"

so the value is padded with leading spaces, and real output looks like:

    VCP code 0x10 (Brightness ...): current value =   100, max value =   100

The single literal space in the regex matches the first space; then [0-9]\+
lands on another space instead of a digit and the match fails, so sed prints
nothing and the script returns "unavailable". Because brightness is 0-100
(3 digits or fewer), the %5d padding always leaves multiple spaces, so the
regex does not match a brightness reading.

I have not built and run every ddcutil release, but the %5d format string is
unchanged in the source from v0.5.0 through the current 2.2.x line, so I would
expect this to affect all reasonably recent versions rather than being specific
to mine (tested on 2.2.7). If anyone sees single-space output on some build,
that is worth knowing. The proposed fix tolerates both either way.

## Fix

Change the literal space to "= *" (zero or more spaces) so the expression
tolerates the padding. It still matches single-space output, so it should be
safe regardless of ddcutil version.

## Reproduction / testing

On ddcutil 2.2.7, running the shipped script unmodified:

    $ ExternalBrightness.sh --get
    {"text":"󰃜 N/A", ... "class":"brightness-external-off"}

After the change:

    $ ExternalBrightness.sh --get
    {"text":"󰃠 100%", ... "class":"brightness-external"}

--inc / --dec also work after the fix. I confirmed the unmodified regex returns
an empty capture against real getvcp output, and the "= *" version returns the
value.

## Scope

This only affects the custom/brightness_external module, which is the opt-in
path for controlling external monitors over DDC (for example a desktop with no
internal panel, where /sys/class/backlight is empty and the default backlight
module does not apply). That module is defined in ModulesCustom but is not
placed in a default bar layout, so it is only reached by users who add it
themselves. That is likely why this has gone unreported: the people who hit it
are the subset who both enable the module and have a DDC-capable external
display. For them the widget is unusable as written.

This PR is intentionally limited to the parse fix. It does not change behavior,
defaults, or module placement.

Note: I meant to send this one :)
