### PR TITLE
docs: Updated change log, fixed fullscreen keybind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@
     - Not supported and no longer needed
   - Reset binding for fullscreen and maximize
     - `SUPER + F` is maximize
-    - `SHIFT + SHIFT + F` is fullscreen
+    - `SUPER + SHIFT + F` is fullscreen
     - Now works in all layouts
   - Enabled 12 min timer on turning off monitor
     - For a very long that's been disabled by default


### PR DESCRIPTION
# Pull Request

## Description

In CHANGELOG.MD (Line 144), binding for fullscreen was incorrect: `SHIFT + SHIFT + F` and it's fixed by changing first `SHIFT` to `SUPER`

## Type of change


- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x ] My change requires a change to the documentation.
- [ x] I want to add something in Hyprland-Dots wiki.
- [ x] I have added tests to cover my changes.
- [ x] I have tested my code locally and it works as expected.
- [ x] All new and existing tests passed.