### PR TITLE
Update fake fullscreen bind on hint menu

### DIFF
--- a/config/hypr/scripts/KeyHints.sh
+++ b/config/hypr/scripts/KeyHints.sh
@@ -61,7 +61,7 @@ GDK_BACKEND=$BACKEND yad \
   "CTRL ALT L" "screen lock" "(hyprlock)" \
   "CTRL ALT Del" "Hyprland Exit" "(NOTE: Hyprland Will exit immediately)" \
   " SHIFT F" "Fullscreen" "Toggles to full screen" \
-  " CTL F" "Fake Fullscreen" "Toggles to fake full screen" \
+  " F" "Fake Fullscreen" "Toggles to fake full screen" \
   " ALT L" "Toggle Dwindle|Scrolling|Monocle|Master layouts" "Active workspace layout" \
   " SPACEBAR" "Toggle float" "single window" \
   " ALT SPACEBAR" "Toggle all windows to float" "all windows" \


### PR DESCRIPTION
## Description

The fake fullscreen bind has been updated from `Meta+Ctrl+F` to `Meta+F`, but the hint menu doesn't reflect this change.

## Type of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [X] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Marked this as both bug fix and documentation since the change is purely visual to the hint menu and doesn't change any behaviour. But it doesn't require any change in the proper documentation.
