### PR TITLE
fix: Toggle all Waybar clock modules between 12H and 24H

### DIFF
--- a/config/hypr/scripts/ToggleWaybarTime.sh
+++ b/config/hypr/scripts/ToggleWaybarTime.sh
@@ -7,7 +7,48 @@
 # ==================================================
 # Toggle Waybar clock format between 12H and 24H
 
-MODULES_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/waybar/Modules"
+WAYBAR_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/waybar"
+
+# Files that hold toggleable clock formats
+MODULES_FILES=(
+  "$WAYBAR_DIR/Modules"         # clock, clock#2, clock#3, clock#4, clock#5
+  "$WAYBAR_DIR/ModulesVertical" # clock#vertical
+)
+
+# Nerd Font clock glyph (U+F017) used by the "clock" and "clock#2" formats.
+# Spelled out as a codepoint on purpose: a literal glyph here is easy to
+# replace with a look-alike from a different Private Use range, which would
+# make the patterns below stop matching without any visible difference.
+CLOCK_GLYPH=$'\uf017'
+# Nerd Font calendar glyph (U+F073), used by the clock#vertical formats
+CAL_GLYPH=$'\uf073'
+
+# Clock format pairs. FORMATS_12H[n] and FORMATS_24H[n] belong to the same
+# module: toggling comments out the one and uncomments the other.
+#
+# The strings must match the "format" values in MODULES_FILES *verbatim*,
+# including the {:L...} locale prefix and every space. A format that is not
+# listed here, or listed with a typo, is silently left on whatever it is
+# currently set to - so keep this list in sync when adding or editing a clock
+# module.
+FORMATS_12H=(
+  "$CLOCK_GLYPH {:%I:%M %p}"           # clock
+  "$CLOCK_GLYPH {:%I:%M %p}"           # clock#2
+  '{:L%I:%M %p - %d/%b}'               # clock#3
+  '{:L%B | %a %d, %Y | %I:%M %p}'      # clock#4
+  '{:%A, %I:%M %P}'                    # clock#5
+  "$CLOCK_GLYPH\n{:%I\n%M\n%p\n\n$CAL_GLYPH \n%d\n%m\n%y}"   # clock#vertical
+)
+
+FORMATS_24H=(
+  "$CLOCK_GLYPH {:%H:%M:%S}"           # clock
+  "$CLOCK_GLYPH  {:%H:%M}"             # clock#2
+  '{:L%H:%M - %d/%b}'                  # clock#3
+  '{:L%B | %a %d, %Y | %H:%M}'         # clock#4
+  '{:%a %d | %H:%M}'                   # clock#5
+  "$CLOCK_GLYPH\n{:%H\n%M\n%S\n\n$CAL_GLYPH \n%d\n%m\n%y}"   # clock#vertical
+)
+
 notify_swaync() {
   command -v notify-send >/dev/null 2>&1 || return 0
   export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
@@ -22,37 +63,75 @@ notify_swaync() {
     notify-send -a "Waybar Time" -u low -t 2000 -i "$icon" "$@" >/dev/null 2>&1 || true
 }
 
-if [ ! -f "$MODULES_FILE" ]; then
-  notify_swaync "Modules file not found: $MODULES_FILE"
+# Only work on the files that are actually present
+FILES=()
+for f in "${MODULES_FILES[@]}"; do
+  [ -f "$f" ] && FILES+=("$f")
+done
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  notify_swaync "No Waybar modules file found in: $WAYBAR_DIR"
   exit 1
 fi
 
+# Escape the characters that are special inside a sed BRE, plus the '#' we use
+# as the s/// delimiter. Needed because the formats contain '.', '*' and the
+# literal backslashes of clock#vertical.
+escape_bre() {
+  printf '%s' "$1" | sed 's/[][\\.*^$#]/\\&/g'
+}
+
+# Comment out / re-enable the "format" line carrying the given format string
+comment_out() {
+  local file="$1" esc
+  esc=$(escape_bre "$2")
+  sed -i "s#^\([[:space:]]*\)\(\"format\":[[:space:]]*\"${esc}\".*\)#\1//\2#" "$file"
+}
+
+uncomment() {
+  local file="$1" esc
+  esc=$(escape_bre "$2")
+  sed -i "s#^\([[:space:]]*\)//[[:space:]]*\(\"format\":[[:space:]]*\"${esc}\".*\)#\1\2#" "$file"
+}
+
+# $1: 12h | 24h
+apply_format() {
+  local target="$1" file i
+  for file in "${FILES[@]}"; do
+    for i in "${!FORMATS_12H[@]}"; do
+      if [ "$target" = "24h" ]; then
+        comment_out "$file" "${FORMATS_12H[$i]}"
+        uncomment "$file" "${FORMATS_24H[$i]}"
+      else
+        comment_out "$file" "${FORMATS_24H[$i]}"
+        uncomment "$file" "${FORMATS_12H[$i]}"
+      fi
+    done
+  done
+}
+
+# True when any clock module is currently on a 12H format. %I is the 12-hour
+# hour and appears in every 12H format; the anchor skips commented lines.
 is_12h_active() {
-  grep -qE '^[[:space:]]*"format":[[:space:]]*" {:%I:%M %p}"' "$MODULES_FILE"
+  grep -qE '^[[:space:]]*"format":.*%I' "${FILES[@]}"
 }
 
-apply_12h() {
-  sed -i 's#^\([[:space:]]*\)//\("format": " {:%I:%M %p}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": " {:%H:%M:%S}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "  {:%H:%M}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%I:%M %p - %d/%b}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%H:%M - %d/%b}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%B | %a %d, %Y | %I:%M %p}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%B | %a %d, %Y | %H:%M}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%A, %I:%M %P}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%a %d | %H:%M}".*\)#\1//\2#' "$MODULES_FILE"
+snapshot() {
+  cat "${FILES[@]}" | cksum
 }
 
-apply_24h() {
-  sed -i 's#^\([[:space:]]*\)\("format": " {:%I:%M %p}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": " {:%H:%M:%S}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "  {:%H:%M}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%I:%M %p - %d/%b}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%H:%M - %d/%b}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%B | %a %d, %Y | %I:%M %p}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%B | %a %d, %Y | %H:%M}".*\)#\1\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)\("format": "{:%A, %I:%M %P}".*\)#\1//\2#' "$MODULES_FILE"
-  sed -i 's#^\([[:space:]]*\)//\("format": "{:%a %d | %H:%M}".*\)#\1\2#' "$MODULES_FILE"
+# Report formats that are not present in any modules file at all. Catches the
+# case where a format above drifts away from the modules files, which would
+# otherwise leave that one clock module silently stuck on its old setting.
+warn_unknown_formats() {
+  local i missing=0
+  for i in "${!FORMATS_12H[@]}"; do
+    grep -qF "\"${FORMATS_12H[$i]}\"" "${FILES[@]}" ||
+      { printf 'Waybar Time: 12H format not found in any modules file: %s\n' "${FORMATS_12H[$i]}" >&2; missing=1; }
+    grep -qF "\"${FORMATS_24H[$i]}\"" "${FILES[@]}" ||
+      { printf 'Waybar Time: 24H format not found in any modules file: %s\n' "${FORMATS_24H[$i]}" >&2; missing=1; }
+  done
+  return $missing
 }
 
 restart_waybar() {
@@ -88,12 +167,23 @@ restart_waybar() {
   fi
 }
 
+warn_unknown_formats || true
+
+before=$(snapshot)
+
 if is_12h_active; then
-  apply_24h
+  apply_format 24h
   mode="24H"
 else
-  apply_12h
+  apply_format 12h
   mode="12H"
+fi
+
+# Nothing replaced means the formats above drifted away from the modules files
+if [ "$before" = "$(snapshot)" ]; then
+  notify_swaync "Clock format unchanged - no known format matched"
+  printf 'Waybar Time: no clock format matched, nothing changed\n' >&2
+  exit 1
 fi
 
 restart_waybar


### PR DESCRIPTION
# Pull Request

## Description

`ToggleWaybarTime.sh` only switched some of the clock modules. Toggling to 24H left `clock#3`, `clock#4` and `clock#vertical` on whatever they were set to, and the script still restarted Waybar and reported `Switched to 24H format`.

Two causes:

**1. Missing `{:L...}` locale prefix.** Each format had its own hardcoded `sed` pattern, and two of them did not match the lines in `Modules`:

| | |
|---|---|
| `Modules` line 136 | `"format": "{:L%H:%M - %d/%b}"` |
| script | `"format": "{:%H:%M - %d/%b}"` |
| `Modules` line 142 | `"format": "{:L%B \| %a %d, %Y \| %I:%M %p}"` |
| script | `"format": "{:%B \| %a %d, %Y \| %I:%M %p}"` |

**2. `ModulesVertical` was never touched.** The script only ever edited `Modules`, so `clock#vertical` — used by every LEFT/RIGHT layout — was out of reach.

`sed -i` exits 0 when nothing matches, so neither failure was visible anywhere.

### Changes

- Replace the 18 hardcoded `sed` patterns with a table of 12H/24H format pairs and build the expressions from it, so both directions come from one source of truth instead of being maintained separately.
- Add `ModulesVertical` to the files being edited.
- Spell the Nerd Font glyphs as codepoints (`$''`, `$''`) instead of literal characters. Not cosmetic: a look-alike glyph from a different Private Use range breaks the matching with no visible difference in an editor — I hit exactly that while writing this fix.
- Warn on stderr about formats that no longer appear in any modules file. Against the bug above this prints `12H format not found in any modules file: {:L%I:%M %p - %d/%b}`.
- Exit non-zero instead of restarting Waybar when a toggle changed nothing at all.

No dependencies, no related issue.

### Not included

- The shipped defaults in `Modules` are inconsistent: `clock`, `clock#2` and `clock#5` ship as 12H while `clock#3` and `clock#4` ship as 24H. That is a behaviour change for every user rather than part of this bug, and with the fix the first toggle normalises everything anyway. Happy to do it as a follow-up if wanted.
- `clock#forest` in `configs/TOP-Everforest` has only a single 24H format and no 12H counterpart, so there is nothing to toggle without inventing one.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

The repo has no test harness, so the last two are unchecked — testing was manual, described below.

## Additional context

Tested against copies of `Modules` and `ModulesVertical` in a sandboxed `XDG_CONFIG_HOME`, with `restart_waybar` stubbed out:

- run 1 → all **six** clock modules on 24H (before this change: three)
- run 2 → all six on 12H, including `clock#3`, `clock#4` and `clock#vertical`
- run 3 → byte-identical to run 1, so the round trip is stable
- with the `L` prefix artificially stripped, the new drift warning fires for exactly the four affected formats

Also ran unsandboxed on my own install (Debian 14, Hyprland 0.56.2, Waybar built from source, `TOP-Default-Laptop` layout): clock switches to 24H and Waybar restarts cleanly.
