### PR TITLE
fix: Keep Waybar alive when switching themes from a bar module

### DIFF
--- a/config/hypr/scripts/DarkLight.sh
+++ b/config/hypr/scripts/DarkLight.sh
@@ -354,7 +354,11 @@ ${SCRIPTSDIR}/WallustSwww.sh
 if [ "$no_restart" -eq 0 ]; then
     sleep 2
     # kill process
-    for pid1 in waybar rofi swaync ags swaybg; do
+    # NOTE: waybar is deliberately excluded here. This script is usually launched from a
+    # waybar module on-click, so it lives in waybar.service's cgroup. Killing waybar makes
+    # systemd tear down the whole unit, taking this script with it before Refresh.sh runs.
+    # Refresh.sh restarts waybar detached from that cgroup instead.
+    for pid1 in rofi swaync ags swaybg; do
         killall "$pid1"
     done
     sleep 1

--- a/config/hypr/scripts/Refresh.sh
+++ b/config/hypr/scripts/Refresh.sh
@@ -47,38 +47,42 @@ for pid in $(pidof rofi swaync ags swaybg); do
   sleep 0.1
 done
 
-# Restart waybar once (works with systemd user unit or manual launch setups)
+# Does a waybar.service user unit exist? Checks LoadState rather than is-enabled: the
+# unit is usually started on demand by WaybarStartup.sh and left disabled, so is-enabled
+# reports "disabled" for a setup that is nevertheless systemd-managed.
+waybar_unit_exists() {
+  local load_state
+  command -v systemctl >/dev/null 2>&1 || return 1
+  load_state="$(systemctl --user show waybar.service --property=LoadState --value 2>/dev/null || true)"
+  [ -n "$load_state" ] && [ "$load_state" != "not-found" ]
+}
+
+# Restart waybar once, DETACHED from this script's cgroup.
+# This script is typically invoked from a waybar module on-click (e.g. DarkLight.sh), so
+# it runs inside waybar.service's cgroup. Killing waybar from in there makes systemd tear
+# down the whole unit and every process in it - this script included - so the replacement
+# waybar never gets launched and the bar stays gone. Running the restart as a transient
+# systemd unit puts it outside that cgroup, where it survives the teardown.
 restart_waybar() {
-  local manage_with_systemd=0
+  local restart_cmd
 
-  if command -v systemctl >/dev/null 2>&1; then
-    if systemctl --user --quiet is-active graphical-session.target 2>/dev/null || systemctl --user --quiet is-active wayland-session@*.target 2>/dev/null; then
-      if systemctl --user --quiet is-active waybar.service 2>/dev/null || systemctl --user --quiet is-enabled waybar.service 2>/dev/null; then
-        manage_with_systemd=1
-      fi
-    fi
-  fi
-
-  if [ "$manage_with_systemd" -eq 1 ]; then
-    systemctl --user stop waybar.service >/dev/null 2>&1 || true
-  fi
-
-  pkill -x waybar >/dev/null 2>&1 || true
-  pkill -x '.waybar-wrapped' >/dev/null 2>&1 || true
-  sleep 0.2
-  if pgrep -x waybar >/dev/null 2>&1 || pgrep -x '.waybar-wrapped' >/dev/null 2>&1; then
-    pkill -9 -x waybar >/dev/null 2>&1 || true
-    pkill -9 -x '.waybar-wrapped' >/dev/null 2>&1 || true
-  fi
-  sleep 0.2
-
-  if [ "$manage_with_systemd" -eq 1 ]; then
-    if ! systemctl --user start waybar.service >/dev/null 2>&1; then
-      waybar >/dev/null 2>&1 &
-    fi
+  if waybar_unit_exists; then
+    restart_cmd='pkill -x waybar; pkill -x .waybar-wrapped; sleep 0.3; systemctl --user reset-failed waybar.service >/dev/null 2>&1; exec systemctl --user restart waybar.service'
   else
-    waybar >/dev/null 2>&1 &
+    restart_cmd='pkill -x waybar; pkill -x .waybar-wrapped; sleep 0.3; exec waybar'
   fi
+
+  if command -v systemd-run >/dev/null 2>&1 &&
+    systemd-run --user --collect --quiet --no-block \
+      --setenv=WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-}" \
+      --setenv=XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" \
+      --setenv=HYPRLAND_INSTANCE_SIGNATURE="${HYPRLAND_INSTANCE_SIGNATURE:-}" \
+      /bin/bash -c "$restart_cmd" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Fallback when systemd-run is unavailable: detach as far as we can.
+  setsid /bin/bash -c "$restart_cmd" >/dev/null 2>&1 &
 }
 
 restart_waybar


### PR DESCRIPTION
# Pull Request

## Description

Switching Dark/Light from the Waybar module leaves the bar gone until the next login.

`DarkLight.sh` is wired to a Waybar module on-click (`ModulesCustom` → `Kool_Quick_Settings.sh`, and the theme switcher from there), so it runs inside `waybar.service`'s cgroup. Its cleanup loop kills waybar, systemd tears down the whole unit, and every process in that cgroup goes with it — `DarkLight.sh` included, before it ever reaches `Refresh.sh`. Nothing is left to start the replacement bar.

`Refresh.sh` had the same problem standing on its own: it killed waybar and then relaunched it from a shell that had just been torn down along with it.

### Changes

- Drop `waybar` from the `DarkLight.sh` cleanup loop and let `Refresh.sh` own the restart.
- Run the restart as a transient `systemd-run --user` unit, so it sits outside the caller's cgroup and survives the teardown. `setsid` fallback where `systemd-run` is unavailable.
- Detect systemd management via the unit's `LoadState` instead of `is-enabled`. `WaybarStartup.sh` starts the unit on demand and leaves it disabled, so `is-enabled` reports `disabled` for setups that are in fact systemd-managed.

No dependencies, no related issue.

### Note on the systemd detection

This replaces the `graphical-session.target` + `is-active || is-enabled` guard that `development` currently carries in `Refresh.sh`. On a running session the two agree — here `LoadState=loaded`, `is-active=active`, `is-enabled=disabled`, so both paths pick systemd. They only diverge when waybar is not currently running, where `LoadState` still recognises a unit-managed setup and the old guard falls through to a bare `waybar &`.

Happy to keep the existing guard and change only the execution to be detached if you prefer the smaller diff — the cgroup teardown is the actual bug, the detection change is a correctness cleanup that came with it.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

The repo has no test harness, so the last two are unchecked.

## Additional context

Environment: Debian 14, Hyprland 0.56.2, Waybar built from source, started by `WaybarStartup.sh`, `TOP-Default-Laptop` layout.

The premise checks out on that setup — waybar lives in its own unit cgroup:

```
$ cat /proc/$(pgrep -x waybar)/cgroup
0::/user.slice/user-1000.slice/user@1000.service/app.slice/waybar.service
```

The fix has been running on that install since before this PR: theme switching from the bar module keeps the bar alive across the restart. Both scripts pass `bash -n`.

Related: PR #95 touches `ToggleWaybarTime.sh`, which still carries the old non-detached `restart_waybar` and is reachable from the same Waybar on-click path, so it can hit this bug too. Kept out of this PR to keep the two independent — glad to follow up once one of them lands.
