### PR TITLE
fix: prevent wallpaper daemon race on concurrent starts

### DIFF
--- a/config/hypr/scripts/DarkLight.sh
+++ b/config/hypr/scripts/DarkLight.sh
@@ -122,7 +122,7 @@ fi
 
 
 # Initialize wallpaper daemon if needed
-"$WWW_CMD" query || "$WWW_DAEMON" "${WWW_DAEMON_ARGS[@]}"
+wallpaper_ensure_daemon
 
 # Set swww options
 swww="$WWW_CMD img"

--- a/config/hypr/scripts/WallpaperCmd.sh
+++ b/config/hypr/scripts/WallpaperCmd.sh
@@ -119,4 +119,39 @@ wallpaper_resize_mode() {
   # Auto mode prefers full-screen fill; set WALLPAPER_RESIZE_MODE=fit to preserve full image.
   printf '%s\n' "crop"
 }
+# Start the wallpaper daemon exactly once, even when several scripts race.
+#
+# Checking with "query" or "pgrep" and then starting is not atomic: two
+# callers can both observe "not running" and both spawn a daemon. The loser
+# panics with "There is an awww-daemon instance already running on this
+# socket!" and aborts (SIGABRT), leaving a core dump behind.
+#
+# This happens on a regular login, where Startup_Apps.conf runs
+# WallpaperDaemon.sh and ApplyThemeMode.sh -> DarkLight.sh concurrently.
+wallpaper_ensure_daemon() {
+  local lock_file="${XDG_RUNTIME_DIR:-/tmp}/wallpaper-daemon.lock"
+
+  command -v "$WWW_DAEMON" >/dev/null 2>&1 || return 1
+  command -v "$WWW_CMD" >/dev/null 2>&1 || return 1
+
+  {
+    # Without flock, fall back to the previous behaviour instead of failing.
+    if command -v flock >/dev/null 2>&1; then
+      flock 9 || return 1
+    fi
+
+    if ! "$WWW_CMD" query >/dev/null 2>&1; then
+      # 9>&- keeps the daemon from inheriting the lock descriptor, which
+      # would hold the lock for its entire lifetime and block every later
+      # caller.
+      "$WWW_DAEMON" "${WWW_DAEMON_ARGS[@]}" 9>&- &
+
+      for _ in {1..50}; do
+        "$WWW_CMD" query >/dev/null 2>&1 && break
+        sleep 0.1
+      done
+    fi
+  } 9>"$lock_file"
+}
+
 export WWW_CMD WWW_DAEMON WWW_CACHE_DIR WWW_DAEMON_ARGS WWW_MIGRATION_MARKER

--- a/config/hypr/scripts/WallpaperDaemon.sh
+++ b/config/hypr/scripts/WallpaperDaemon.sh
@@ -11,15 +11,7 @@ SCRIPTSDIR="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/scripts"
 # shellcheck source=/dev/null
 . "$SCRIPTSDIR/WallpaperCmd.sh"
 
-if command -v "$WWW_DAEMON" >/dev/null 2>&1 && command -v "$WWW_CMD" >/dev/null 2>&1 && ! pgrep -x "$WWW_DAEMON" >/dev/null 2>&1; then
-  "$WWW_DAEMON" "${WWW_DAEMON_ARGS[@]}" &
-fi
-
-# Give the daemon a moment to become ready
-for _ in {1..50}; do
-  "$WWW_CMD" query >/dev/null 2>&1 && break
-  sleep 0.1
-done
+wallpaper_ensure_daemon
 
 wallpaper_link="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/.current_wallpaper"
 wallpaper_current="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/wallpaper_effects/.wallpaper_current"

--- a/config/hypr/scripts/WallpaperRandom.sh
+++ b/config/hypr/scripts/WallpaperRandom.sh
@@ -30,9 +30,7 @@ if [[ "$WWW_CMD" == "swww" || "$WWW_CMD" == "awww" ]]; then
 else
   SWWW_PARAMS=()
 fi
-if ! "$WWW_CMD" query >/dev/null 2>&1; then
-  "$WWW_DAEMON" "${WWW_DAEMON_ARGS[@]}" &
-fi
+wallpaper_ensure_daemon
 resize_mode="$(wallpaper_resize_mode "$RANDOMPICS" "$focused_monitor")"
 "$WWW_CMD" img -o "$focused_monitor" --resize "$resize_mode" "$RANDOMPICS" "${SWWW_PARAMS[@]}"
 

--- a/config/hypr/scripts/WallpaperSelect.sh
+++ b/config/hypr/scripts/WallpaperSelect.sh
@@ -161,15 +161,7 @@ apply_image_wallpaper() {
 
   kill_wallpaper_for_image
 
-  if ! pgrep -x "$WWW_DAEMON" >/dev/null; then
-    echo "Starting $WWW_DAEMON..."
-    "$WWW_DAEMON" "${WWW_DAEMON_ARGS[@]}" &
-  fi
-  # Wait for daemon to be ready before applying
-  for _ in {1..20}; do
-    "$WWW_CMD" query >/dev/null 2>&1 && break
-    sleep 0.1
-  done
+  wallpaper_ensure_daemon
   local resize_mode
   resize_mode="$(wallpaper_resize_mode "$image_path" "$focused_monitor")"
   "$WWW_CMD" img -o "$focused_monitor" --resize "$resize_mode" "$image_path" "${SWWW_PARAMS[@]}" || {


### PR DESCRIPTION
## Description

`Startup_Apps.conf` runs `WallpaperDaemon.sh` and `ApplyThemeMode.sh` ->
`DarkLight.sh` concurrently. Both start the wallpaper daemon, and all guards
are check-then-start (`pgrep` or `query`), which is not atomic. When both see
"not running", both spawn a daemon and the loser aborts:

```
thread '<unnamed>' panicked at daemon/src/main.rs:717:55:
called `Result::unwrap()` on an `Err` value:
"There is an awww-daemon instance already running on this socket!"
```

One daemon survives, so the desktop works and this is easy to miss, but it
leaves a SIGABRT core dump on every affected login.

Adds `wallpaper_ensure_daemon()` to `WallpaperCmd.sh` (already sourced by all
wallpaper scripts) and uses it in the four callers. It holds an `flock` across
check and start. The daemon gets `9>&-` so it does not inherit the lock fd and
hold the lock for its lifetime. Without `flock` the old behaviour is kept.

Note: `WallpaperSelect.sh` loses its `echo "Starting ..."` line and its
readiness wait goes 20 -> 50, matching the other callers.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Arch, Hyprland 0.56.2, awww 0.12.1-1, Hyprland-Dots-v2.3.25

