### PR TITLE
swaync: add missing semicolons in style.css

### DIFF
--- a/config/swaync/style.css
+++ b/config/swaync/style.css
@@ -19,7 +19,7 @@
 .control-center .notification-row:hover {
     opacity: 1;
     background: @noti-bg;
-    border-radius: 10px
+    border-radius: 10px;
 }
 
 .notification-row {
@@ -54,7 +54,7 @@
     box-shadow: none;
     background: #f7768e;
     transition: all .15s ease-in-out;
-    border: none
+    border: none;
 }
 
 
@@ -68,7 +68,7 @@
 .notification-default-action:hover,
 .notification-action:hover {
     color: @text-color;
-    background: @noti-bg
+    background: @noti-bg;
 }
 
 
@@ -79,21 +79,21 @@
 
 .notification-default-action:not(:only-child) {
     border-bottom-left-radius: 7px;
-    border-bottom-right-radius: 7px
+    border-bottom-right-radius: 7px;
 }
 
 .notification-action:first-child {
     border-bottom-left-radius: 10px;
-    background: @noti-bg
+    background: @noti-bg;
 }
 
 .notification-action:last-child {
     border-bottom-right-radius: 10px;
-    background: @noti-bg-alt
+    background: @noti-bg-alt;
 }
 
 .inline-reply {
-    margin-top: 8px
+    margin-top: 8px;
 }
 
 .inline-reply-entry {
@@ -101,7 +101,7 @@
     color: @text-color;
     caret-color: @text-color;
     border: 1px solid @noti-border-color;
-    border-radius: 10px
+    border-radius: 10px;
 }
 
 .inline-reply-button {
@@ -110,23 +110,23 @@
     background: @noti-bg;
     border: 1px solid @noti-border-color;
     border-radius: 10px;
-    color: @text-color
+    color: @text-color;
 }
 
 .inline-reply-button:disabled {
     background: initial;
     color: @text-color;
-    border: 1px solid transparent
+    border: 1px solid transparent;
 }
 
 .inline-reply-button:hover {
-    background: @noti-bg-hover
+    background: @noti-bg-hover;
 }
 
 .body-image {
     margin-top: 6px;
     color: @text-color;
-    border-radius: 10px
+    border-radius: 10px;
 }
 
 .summary {
@@ -134,7 +134,7 @@
     font-weight: bold;
     background: transparent;
     color: @text-color;
-    text-shadow: none
+    text-shadow: none;
 }
 
 .time {
@@ -143,7 +143,7 @@
     background: transparent;
     color: @text-color;
     text-shadow: none;
-    margin-right: 18px
+    margin-right: 18px;
 }
 
 .body {
@@ -151,7 +151,7 @@
     font-weight: bold;
     background: transparent;
     color: @text-color;
-    text-shadow: none
+    text-shadow: none;
 }
 
 .control-center {
@@ -162,11 +162,11 @@
 }
 
 .control-center-list {
-    background: transparent
+    background: transparent;
 }
 
 .control-center-list-placeholder {
-    opacity: 0.5
+    opacity: 0.5;
 }
 
 .floating-notifications {
@@ -174,7 +174,7 @@
 }
 
 .blank-window {
-    background: alpha(black, 0.1)
+    background: alpha(black, 0.1);
 }
 
 .widget-title {
@@ -222,12 +222,12 @@
 
 .widget-dnd>switch slider {
     background: @noti-bg;
-    border-radius: 10px
+    border-radius: 10px;
 }
 
 .widget-dnd>switch:checked slider {
     background: @noti-bg;
-    border-radius: 10px
+    border-radius: 10px;
 }
 
 .widget-label {
@@ -258,11 +258,11 @@
 
 .widget-mpris-title {
     font-weight: 100;
-    font-size: 1rem
+    font-size: 1rem;
 }
 
 .widget-mpris-subtitle {
-    font-size: 0.75rem
+    font-size: 0.75rem;
 }
 
 .widget-buttons-grid {
@@ -278,23 +278,23 @@
     margin: 1px;
     background: @noti-bg;
     border-radius: 10px;
-    color: @text-color
+    color: @text-color;
 }
 
 /* individual buttons */
 .widget-buttons-grid>flowbox>flowboxchild>button:hover {
     background: @text-color;
-    color: @noti-bg-hover
+    color: @noti-bg-hover;
 }
 
 .widget-menubar>box>.menu-button-bar>button {
     border: none;
-    background: transparent
+    background: transparent;
 }
 
 .topbar-buttons>button {
     border: none;
-    background: transparent
+    background: transparent;
 }
 
 .widget-volume {
@@ -303,12 +303,12 @@
     margin: 10px 10px 5px 10px;
     border-radius: 10px;
     font-size: x-large;
-    color: @text-color
+    color: @text-color;
 }
 
 .widget-volume>box>button {
     background: @noti-border-color;
-    border: none
+    border: none;
 }
 
 .per-app-volume {
@@ -316,7 +316,7 @@
     padding: 4px 8px 8px;
     margin: 0 8px 8px;
     border-radius: 10px;
-	color: @text-color
+	color: @text-color;
 }
 
 .widget-backlight {
@@ -325,5 +325,5 @@
     margin: 10px 10px 5px 10px;
     border-radius: 10px;
     font-size: x-large;
-    color: @text-color
+    color: @text-color;
 }


### PR DESCRIPTION
GTK's CSS parser warns whenever the last declaration in a block has no trailing semicolon:

```
Theme parser warning: style.css:22:5-23:1: Expected ';' at end of block
```

There are **30 such blocks** in `config/swaync/style.css`. CSS itself allows the omission, so nothing is broken visually, but every load of the file produces 30 warnings.

swaync reloads its CSS on every wallpaper change. With a wallpaper rotation every 30 minutes that is roughly **1400 log lines per day** from this one file. 

## Changed

Only semicolons were added, nothing was reordered or reformatted. Stripping all trailing semicolons from both the old and the new file yields identical output:

## Verified

Applied locally and swaync restarted: the `style.css` warnings are gone.