### PR TITLE
fix: Detect touchpads automatically

### DIFF
--- a/config/hypr/UserConfigs/Laptops.conf
+++ b/config/hypr/UserConfigs/Laptops.conf
@@ -11,6 +11,10 @@ $mainMod = SUPER
 $scriptsDir = $HOME/.config/hypr/scripts
 $UserConfigs = $HOME/.config/hypr/UserConfigs
 
+# TouchPad.sh detects devices whose name contains "touchpad". Uncomment this
+# only when you need to select a different device explicitly.
+# $Touchpad_Device = your-touchpad-device-name
+
 # Below are useful when you are connecting your laptop in external display
 # Suggest you edit below for your laptop display
 # From WIKI This is to disable laptop monitor when lid is closed.

--- a/config/hypr/UserConfigs/Laptops.conf
+++ b/config/hypr/UserConfigs/Laptops.conf
@@ -11,10 +11,9 @@ $mainMod = SUPER
 $scriptsDir = $HOME/.config/hypr/scripts
 $UserConfigs = $HOME/.config/hypr/UserConfigs
 
-# TouchPad.sh detects devices whose name contains "touchpad". Uncomment this
-# only when you need to select a different device explicitly.
+# TouchPad.sh detects devices whose name contains "touchpad", "trackpad", or "glidepoint".
+# Uncomment this only when you need to select a different device explicitly.
 # $Touchpad_Device = your-touchpad-device-name
-
 # Below are useful when you are connecting your laptop in external display
 # Suggest you edit below for your laptop display
 # From WIKI This is to disable laptop monitor when lid is closed.

--- a/config/hypr/UserConfigs/user_laptops.lua
+++ b/config/hypr/UserConfigs/user_laptops.lua
@@ -8,6 +8,7 @@
 -- Add lid/display behavior here if you need laptop-specific logic.
 
 -- Examples:
+-- Touchpad_Device = "your-touchpad-device-name" -- Optional: TouchPad.sh auto-detects by default
 -- hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = "1" })
 -- hl.monitor({ output = "eDP-1", disabled = true })
 

--- a/config/hypr/configs/Laptops.conf
+++ b/config/hypr/configs/Laptops.conf
@@ -11,9 +11,6 @@ $mainMod = SUPER
 $scriptsDir = $HOME/.config/hypr/scripts
 $UserConfigs = $HOME/.config/hypr/UserConfigs
 
-# for disabling Touchpad. hyprctl devices to get device name. 
-$Touchpad_Device=asue1209:00-04f3:319f-touchpad
-
 bindeld = , xf86KbdBrightnessDown, Decrease keyboard brightness, exec, $scriptsDir/BrightnessKbd.sh --dec
 bindeld = , xf86KbdBrightnessUp, Increase keyboard brightness, exec, $scriptsDir/BrightnessKbd.sh --inc
 bindd = , xf86Launch1, ASUS Armory crate button, exec, rog-control-center
@@ -29,10 +26,4 @@ bind = $mainMod SHIFT, F6, exec, $scriptsDir/ScreenShot.sh --area # screenshot (
 bind = $mainMod CTRL, F6, exec, $scriptsDir/ScreenShot.sh --in5 # # screenshot (5 secs delay)
 bind = $mainMod ALT, F6, exec, $scriptsDir/ScreenShot.sh --in10 # screenshot (10 secs delay)
 bind = ALT, F6, exec, $scriptsDir/ScreenShot.sh --active # screenshot (active window only)
-
-$TOUCHPAD_ENABLED = true
-device {
-  name = $Touchpad_Device
-  enabled = $TOUCHPAD_ENABLED
-}
 

--- a/config/hypr/scripts/TouchPad.sh
+++ b/config/hypr/scripts/TouchPad.sh
@@ -5,9 +5,8 @@
 #  License: GNU GPLv3
 #  SPDX-License-Identifier: GPL-3.0-or-later
 # ==================================================
-# For disabling touchpad.
-# Edit the Touchpad_Device on ${XDG_CONFIG_HOME:-$HOME/.config}/hypr/UserConfigs/Laptops.conf according to your system
-# use hyprctl devices to get your system touchpad device name
+# Toggle the first detected touchpad. Set TOUCHPAD_DEVICE or define
+# $Touchpad_Device in UserConfigs/Laptops.conf to override auto-detection.
 # source https://github.com/hyprwm/Hyprland/discussions/4283?sort=new#discussioncomment-8648109
 
 set -euo pipefail
@@ -28,26 +27,45 @@ if [[ -z "$touchpad_device" && -f "$laptops_conf" ]]; then
 fi
 
 if [[ -z "$touchpad_device" ]]; then
-    notify-send -u low -i "$notif" " Touchpad" " Device name not set (check Laptops.conf)"
+    touchpad_device="$(
+        hyprctl devices -j 2>/dev/null |
+            jq -r 'first(.mice[]?.name | select(test("touchpad"; "i"))) // empty' || true
+    )"
+fi
+
+if [[ -z "$touchpad_device" ]]; then
+    notify-send -u low -i "$notif" " Touchpad" " No touchpad was detected"
     exit 1
 fi
 
-touchpad_keyword="${TOUCHPAD_KEYWORD:-device:${touchpad_device}:enabled}"
-status_file="${XDG_RUNTIME_DIR:-/tmp}/touchpad.status"
+runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+status_file="$runtime_dir/touchpad.status"
+
+set_touchpad_state() {
+    local state="$1"
+
+    # Hyprland 0.55+ uses Lua-style device option paths. Keep the legacy
+    # keyword as a fallback for older supported releases.
+    if hyprctl -r -- keyword "device[$touchpad_device].enabled" "$state" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    hyprctl -r -- keyword "device:${touchpad_device}:enabled" "$state" >/dev/null
+}
 
 enable_touchpad() {
-    printf "true" >"$status_file"
-    notify-send -u low -i "$notif" " Enabling" " touchpad"
-    hyprctl keyword "$touchpad_keyword" true -r
+    set_touchpad_state true
+    printf '%s\n' "true" >"$status_file"
+    notify-send -u low -i "$notif" " Touchpad" " Enabled"
 }
 
 disable_touchpad() {
-    printf "false" >"$status_file"
-    notify-send -u low -i "$notif" " Disabling" " touchpad"
-    hyprctl keyword "$touchpad_keyword" false -r
+    set_touchpad_state false
+    printf '%s\n' "false" >"$status_file"
+    notify-send -u low -i "$notif" " Touchpad" " Disabled"
 }
 
-current_state="false"
+current_state="true"
 if [[ -f "$status_file" ]]; then
     current_state="$(<"$status_file")"
 fi

--- a/config/hypr/scripts/TouchPad.sh
+++ b/config/hypr/scripts/TouchPad.sh
@@ -5,19 +5,22 @@
 #  License: GNU GPLv3
 #  SPDX-License-Identifier: GPL-3.0-or-later
 # ==================================================
-# Toggle the first detected touchpad. Set TOUCHPAD_DEVICE or define
-# $Touchpad_Device in UserConfigs/Laptops.conf to override auto-detection.
+# Toggle the detected or configured touchpad device.
+# Set TOUCHPAD_DEVICE or define Touchpad_Device in UserConfigs (Laptops.conf or user_laptops.lua) to override auto-detection.
 # source https://github.com/hyprwm/Hyprland/discussions/4283?sort=new#discussioncomment-8648109
 
 set -euo pipefail
 
 notif="${XDG_CONFIG_HOME:-$HOME/.config}/swaync/images/ja.png"
 laptops_conf="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/UserConfigs/Laptops.conf"
+user_laptops_lua="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/UserConfigs/user_laptops.lua"
 
 touchpad_device="${TOUCHPAD_DEVICE:-}"
+
+# Check Laptops.conf for legacy override
 if [[ -z "$touchpad_device" && -f "$laptops_conf" ]]; then
     touchpad_device="$(
-        awk -F= '/^\$Touchpad_Device/ {
+        awk -F= '/^[[:space:]]*\$Touchpad_Device/ {
             gsub(/[[:space:]]*/, "", $1);
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2);
             print $2;
@@ -26,15 +29,23 @@ if [[ -z "$touchpad_device" && -f "$laptops_conf" ]]; then
     )"
 fi
 
+# Check user_laptops.lua for Lua override
+if [[ -z "$touchpad_device" && -f "$user_laptops_lua" ]]; then
+    touchpad_device="$(
+        sed -nE 's/^[[:space:]]*(TOUCHPAD_DEVICE|Touchpad_Device|touchpad_device)[[:space:]]*=[[:space:]]*["'\''"]([^"'\''"]+)["'\''"].*/\2/p' "$user_laptops_lua" | tail -n1
+    )"
+fi
+
+# Auto-detect touchpad from hyprctl devices
 if [[ -z "$touchpad_device" ]]; then
     touchpad_device="$(
         hyprctl devices -j 2>/dev/null |
-            jq -r 'first(.mice[]?.name | select(test("touchpad"; "i"))) // empty' || true
+            jq -r 'first(.mice[]?.name | select(test("touchpad|trackpad|glidepoint"; "i"))) // empty' 2>/dev/null || true
     )"
 fi
 
 if [[ -z "$touchpad_device" ]]; then
-    notify-send -u low -i "$notif" " Touchpad" " No touchpad was detected"
+    notify-send -u low -i "$notif" " Touchpad" " No touchpad was detected" 2>/dev/null || true
     exit 1
 fi
 
@@ -44,25 +55,29 @@ status_file="$runtime_dir/touchpad.status"
 set_touchpad_state() {
     local state="$1"
 
-    # Hyprland 0.55+ uses Lua-style device option paths. Keep the legacy
-    # keyword as a fallback for older supported releases.
-    if hyprctl -r -- keyword "device[$touchpad_device].enabled" "$state" >/dev/null 2>&1; then
+    # Hyprland 0.55+ Lua eval path
+    if hyprctl -r eval "hl.device({ name = [[$touchpad_device]], enabled = $state })" >/dev/null 2>&1; then
         return 0
     fi
 
-    hyprctl -r -- keyword "device:${touchpad_device}:enabled" "$state" >/dev/null
+    # Legacy Hyprlang keyword fallback
+    if hyprctl -r -- keyword "device:${touchpad_device}:enabled" "$state" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    hyprctl keyword "device:${touchpad_device}:enabled" "$state" >/dev/null 2>&1 || true
 }
 
 enable_touchpad() {
     set_touchpad_state true
     printf '%s\n' "true" >"$status_file"
-    notify-send -u low -i "$notif" " Touchpad" " Enabled"
+    notify-send -u low -i "$notif" " Touchpad" " Enabled" 2>/dev/null || true
 }
 
 disable_touchpad() {
     set_touchpad_state false
     printf '%s\n' "false" >"$status_file"
-    notify-send -u low -i "$notif" " Touchpad" " Disabled"
+    notify-send -u low -i "$notif" " Touchpad" " Disabled" 2>/dev/null || true
 }
 
 current_state="true"


### PR DESCRIPTION
## Description

`TouchPad.sh` expects the device override in `UserConfigs/Laptops.conf`, but the shared laptop config ships a hardcoded ASUS device name instead. On other laptops the toggle can fail even when a touchpad is present.

This change:

- keeps `TOUCHPAD_DEVICE` and the user config as explicit overrides
- detects the first touchpad through `hyprctl devices -j` when no override is set
- supports both current and legacy Hyprland device keyword syntax
- stores toggle state in `XDG_RUNTIME_DIR`
- removes the machine-specific device from the shared config
- reports a clear error when no touchpad is available

Related: #6

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Documentation update**
- [ ] **Technical debt**
- [ ] **Other**

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the commit guidelines.
- [ ] My change requires a documentation update.
- [ ] I want to add something to the Hyprland-Dots wiki.
- [ ] I have added repository tests.
- [x] I have tested the change locally.
- [x] All applicable checks passed.

## Testing

- ShellCheck and `bash -n`
- mocked automatic detection and explicit override
- mocked current and legacy Hyprland keyword paths
- missing-device failure path
- Hyprland config validation in both legacy and Lua modes

## Screenshots

Not applicable.