### PR TITLE
fix: Support stepped keyboard backlights

### DIFF
--- a/config/hypr/configs/Laptops.conf
+++ b/config/hypr/configs/Laptops.conf
@@ -13,6 +13,7 @@ $UserConfigs = $HOME/.config/hypr/UserConfigs
 
 bindeld = , xf86KbdBrightnessDown, Decrease keyboard brightness, exec, $scriptsDir/BrightnessKbd.sh --dec
 bindeld = , xf86KbdBrightnessUp, Increase keyboard brightness, exec, $scriptsDir/BrightnessKbd.sh --inc
+bindld = , xf86KbdLightOnOff, Cycle keyboard brightness, exec, $scriptsDir/BrightnessKbd.sh --cycle
 bindd = , xf86Launch1, ASUS Armory crate button, exec, rog-control-center
 bindd = , xf86Launch3, Switch keyboard RGB profile, exec, asusctl led-mode -n
 bindd = , xf86Launch4, Change fan profiles, exec, asusctl profile -n
@@ -26,4 +27,3 @@ bind = $mainMod SHIFT, F6, exec, $scriptsDir/ScreenShot.sh --area # screenshot (
 bind = $mainMod CTRL, F6, exec, $scriptsDir/ScreenShot.sh --in5 # # screenshot (5 secs delay)
 bind = $mainMod ALT, F6, exec, $scriptsDir/ScreenShot.sh --in10 # screenshot (10 secs delay)
 bind = ALT, F6, exec, $scriptsDir/ScreenShot.sh --active # screenshot (active window only)
-

--- a/config/hypr/configs/system_keybinds.lua
+++ b/config/hypr/configs/system_keybinds.lua
@@ -751,6 +751,12 @@ bind(
 )
 bind(
   "",
+  "xf86KbdLightOnOff",
+  exec_cmd("$HOME/.config/hypr/scripts/BrightnessKbd.sh --cycle"),
+  { description = "cycle keyboard brightness", locked = true }
+)
+bind(
+  "",
   "xf86TouchpadToggle",
   exec_cmd("$HOME/.config/hypr/scripts/TouchPad.sh"),
   { description = "disable touchpad" }

--- a/config/hypr/lua/keybinds.lua
+++ b/config/hypr/lua/keybinds.lua
@@ -548,6 +548,12 @@ bind(
 )
 bind(
   "",
+  "xf86KbdLightOnOff",
+  exec_cmd("$HOME/.config/hypr/scripts/BrightnessKbd.sh --cycle"),
+  { description = "cycle keyboard brightness", locked = true }
+)
+bind(
+  "",
   "xf86TouchpadToggle",
   exec_cmd("$HOME/.config/hypr/scripts/TouchPad.sh"),
   { description = "disable touchpad" }

--- a/config/hypr/scripts/BrightnessKbd.sh
+++ b/config/hypr/scripts/BrightnessKbd.sh
@@ -5,52 +5,155 @@
 #  License: GNU GPLv3
 #  SPDX-License-Identifier: GPL-3.0-or-later
 # ==================================================
-# Script for keyboard backlights (if supported) using brightnessctl
+# Keyboard backlight controls using the device's native brightness steps.
+
+set -euo pipefail
 
 iDIR="${XDG_CONFIG_HOME:-$HOME/.config}/swaync/icons"
+device="${KBD_BACKLIGHT_DEVICE:-}"
 
-# Get keyboard brightness
-get_kbd_backlight() {
-	echo $(brightnessctl -d '*::kbd_backlight' -m | cut -d, -f4)
+if [[ -z "$device" ]]; then
+    device="$(
+        brightnessctl --list 2>/dev/null |
+            awk -F"'" '/^Device .*kbd_backlight/ && !device { device = $2 } END { print device }'
+    )"
+fi
+
+if [[ -z "$device" ]]; then
+    notify-send -u normal "Keyboard backlight" "No keyboard backlight was detected" >/dev/null 2>&1 || true
+    exit 1
+fi
+
+read_asus_state() {
+    asusctl leds get 2>/dev/null |
+        awk -F': ' '/Current keyboard led brightness/ { print tolower($2); exit }'
 }
 
-# Get icons
-get_icon() {
-	current=$(get_kbd_backlight | sed 's/%//')
-	if   [ "$current" -le "20" ]; then
-		icon="$iDIR/brightness-20.png"
-	elif [ "$current" -le "40" ]; then
-		icon="$iDIR/brightness-40.png"
-	elif [ "$current" -le "60" ]; then
-		icon="$iDIR/brightness-60.png"
-	elif [ "$current" -le "80" ]; then
-		icon="$iDIR/brightness-80.png"
-	else
-		icon="$iDIR/brightness-100.png"
-	fi
-}
-# Notify
-notify_user() {
-	notify-send -e -h string:x-canonical-private-synchronous:brightness_notif -h int:value:$current -h boolean:SWAYNC_BYPASS_DND:true -u low -i "$icon" "Keyboard" "Brightness:$current%"
+backend=brightnessctl
+if [[ "$device" == "asus::kbd_backlight" ]] && command -v asusctl >/dev/null 2>&1; then
+    case "$(read_asus_state || true)" in
+        off|low|med|high) backend=asusctl ;;
+    esac
+fi
+
+read_state() {
+    if [[ "$backend" == "asusctl" ]]; then
+        level_name="$(read_asus_state)"
+        case "$level_name" in
+            off) current=0 ;;
+            low) current=1 ;;
+            med) current=2 ;;
+            high) current=3 ;;
+            *) return 1 ;;
+        esac
+        maximum=3
+    else
+        current="$(brightnessctl -d "$device" get)"
+        maximum="$(brightnessctl -d "$device" max)"
+        [[ "$current" =~ ^[0-9]+$ && "$maximum" =~ ^[1-9][0-9]*$ ]]
+    fi
+
+    percent=$(( (current * 100 + maximum / 2) / maximum ))
 }
 
-# Change brightness
-change_kbd_backlight() {
-	brightnessctl -d *::kbd_backlight set "$1" && get_icon && notify_user
+select_icon() {
+    if (( percent <= 20 )); then
+        icon="$iDIR/brightness-20.png"
+    elif (( percent <= 40 )); then
+        icon="$iDIR/brightness-40.png"
+    elif (( percent <= 60 )); then
+        icon="$iDIR/brightness-60.png"
+    elif (( percent <= 80 )); then
+        icon="$iDIR/brightness-80.png"
+    else
+        icon="$iDIR/brightness-100.png"
+    fi
 }
 
-# Execute accordingly
-case "$1" in
-	"--get")
-		get_kbd_backlight
-		;;
-	"--inc")
-		change_kbd_backlight "+30%"
-		;;
-	"--dec")
-		change_kbd_backlight "30%-"
-		;;
-	*)
-		get_kbd_backlight
-		;;
+notify_state() {
+    local message
+    select_icon
+
+    if [[ "$backend" == "asusctl" ]]; then
+        message="${level_name^}"
+        notify-send -e -u low -i "$icon" \
+            -h string:x-canonical-private-synchronous:keyboard_backlight \
+            -h boolean:SWAYNC_BYPASS_DND:true \
+            "Keyboard backlight" "$message" || true
+    else
+        message="Level $current of $maximum ($percent%)"
+        notify-send -e -u low -i "$icon" \
+            -h string:x-canonical-private-synchronous:keyboard_backlight \
+            -h "int:value:$percent" \
+            -h boolean:SWAYNC_BYPASS_DND:true \
+            "Keyboard backlight" "$message" || true
+    fi
+}
+
+change_level() {
+    local action="$1"
+    local previous previous_name step target
+
+    read_state
+    previous="$current"
+
+    if [[ "$backend" == "asusctl" ]]; then
+        previous_name="$level_name"
+        if [[ "$action" == "dec" ]]; then
+            asusctl leds prev >/dev/null 2>&1
+        else
+            asusctl leds next >/dev/null 2>&1
+        fi
+        read_state
+
+        # next/prev wrap. Brightness keys should stop at the boundaries;
+        # only the dedicated cycle action is allowed to wrap.
+        if [[ "$action" == "inc" ]] && (( current <= previous )); then
+            asusctl leds set "$previous_name" >/dev/null 2>&1
+            read_state
+        elif [[ "$action" == "dec" ]] && (( current >= previous )); then
+            asusctl leds set "$previous_name" >/dev/null 2>&1
+            read_state
+        fi
+    else
+        step=$(( maximum <= 10 ? 1 : (maximum + 9) / 10 ))
+        case "$action" in
+            inc)
+                target=$((current + step))
+                (( target > maximum )) && target="$maximum"
+                ;;
+            dec)
+                target=$((current - step))
+                (( target < 0 )) && target=0
+                ;;
+            cycle)
+                if (( current >= maximum )); then
+                    target=0
+                else
+                    target=$((current + step))
+                    (( target > maximum )) && target="$maximum"
+                fi
+                ;;
+        esac
+        if (( target != current )); then
+            brightnessctl -q -d "$device" set "$target"
+            read_state
+        fi
+    fi
+
+    notify_state
+}
+
+case "${1:---get}" in
+    --get)
+        read_state
+        printf '%s%%\n' "$percent"
+        ;;
+    --inc) change_level inc ;;
+    --dec) change_level dec ;;
+    --cycle|--toggle) change_level cycle ;;
+    *)
+        printf 'Usage: %s {--get|--inc|--dec|--cycle}\n' "${0##*/}" >&2
+        exit 2
+        ;;
 esac

--- a/config/hypr/scripts/BrightnessKbd.sh
+++ b/config/hypr/scripts/BrightnessKbd.sh
@@ -19,6 +19,12 @@ if [[ -z "$device" ]]; then
     )"
 fi
 
+if [[ -z "$device" ]] && command -v asusctl >/dev/null 2>&1; then
+    if asusctl leds get >/dev/null 2>&1; then
+        device="asus::kbd_backlight"
+    fi
+fi
+
 if [[ -z "$device" ]]; then
     notify-send -u normal "Keyboard backlight" "No keyboard backlight was detected" >/dev/null 2>&1 || true
     exit 1
@@ -26,7 +32,7 @@ fi
 
 read_asus_state() {
     asusctl leds get 2>/dev/null |
-        awk -F': ' '/Current keyboard led brightness/ { print tolower($2); exit }'
+        awk -F': ' '/Current keyboard led brightness/ { val = tolower($2); gsub(/^[[:space:]]+|[[:space:]]+$/, "", val); print val; exit }'
 }
 
 backend=brightnessctl
@@ -48,11 +54,12 @@ read_state() {
         esac
         maximum=3
     else
-        current="$(brightnessctl -d "$device" get)"
-        maximum="$(brightnessctl -d "$device" max)"
+        current="$(brightnessctl -d "$device" get 2>/dev/null || echo 0)"
+        maximum="$(brightnessctl -d "$device" max 2>/dev/null || echo 1)"
         [[ "$current" =~ ^[0-9]+$ && "$maximum" =~ ^[1-9][0-9]*$ ]]
     fi
 
+    (( maximum < 1 )) && maximum=1
     percent=$(( (current * 100 + maximum / 2) / maximum ))
 }
 
@@ -79,14 +86,14 @@ notify_state() {
         notify-send -e -u low -i "$icon" \
             -h string:x-canonical-private-synchronous:keyboard_backlight \
             -h boolean:SWAYNC_BYPASS_DND:true \
-            "Keyboard backlight" "$message" || true
+            "Keyboard backlight" "$message" >/dev/null 2>&1 || true
     else
         message="Level $current of $maximum ($percent%)"
         notify-send -e -u low -i "$icon" \
             -h string:x-canonical-private-synchronous:keyboard_backlight \
             -h "int:value:$percent" \
             -h boolean:SWAYNC_BYPASS_DND:true \
-            "Keyboard backlight" "$message" || true
+            "Keyboard backlight" "$message" >/dev/null 2>&1 || true
     fi
 }
 
@@ -136,7 +143,7 @@ change_level() {
                 ;;
         esac
         if (( target != current )); then
-            brightnessctl -q -d "$device" set "$target"
+            brightnessctl -q -d "$device" set "$target" >/dev/null 2>&1 || true
             read_state
         fi
     fi


### PR DESCRIPTION
## Description

The keyboard backlight helper relies on a wildcard device and fixed percentage changes. That is unreliable on stepped devices and on laptops that expose only `XF86KbdLightOnOff`.

This change:

- detects the exact `kbd_backlight` device
- keeps `KBD_BACKLIGHT_DEVICE` as an explicit override
- uses native steps for low-range devices and bounded steps for larger ranges
- uses `asusctl` when an ASUS keyboard exposes that backend
- prevents brightness up/down from wrapping at their boundaries
- adds a dedicated cycle action for toggle-only keys
- adds `XF86KbdLightOnOff` bindings to legacy and Lua configs
- gives keyboard notifications their own replacement ID

The ASUS backend matters on a ProArt P16: the kernel advertises raw levels 0-3, but this model maps them as off/low/off/low. `asusctl leds next/prev` reports the usable states correctly.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Documentation update**
- [ ] **Technical debt**
- [ ] **Other**

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the commit guidelines.
- [ ] My change requires a documentation update.
- [ ] I want to add something to the Hyprland-Dots wiki.
- [ ] I have added repository tests.
- [x] I have tested the change locally.
- [x] All applicable checks passed.

## Testing

- ShellCheck and `bash -n`
- mocked 0-3 and 0-255 brightness ranges
- mocked device override and missing-device paths
- live `asus::kbd_backlight` testing on an ASUS ProArt P16
- verified up/down boundaries and toggle cycling
- Hyprland config validation in both legacy and Lua modes

## Screenshots

Not applicable.