### PR TITLE
fix: Let Waybar detect the display backlight

### DIFF
--- a/config/waybar/Modules
+++ b/config/waybar/Modules
@@ -50,7 +50,6 @@
 },
 
 "backlight#2": {
-  "device": "intel_backlight",
   "format": "{icon} {percent}%",
   "format-icons": ["", ""]
 },

--- a/config/waybar/configs/BOT-Camellia
+++ b/config/waybar/configs/BOT-Camellia
@@ -66,8 +66,7 @@
 "backlight/slider": {
 	"min": 0,
 	"max": 100,
-	"orientation": "horizontal",
-	"device": "intel_backlight"
+	"orientation": "horizontal"
 },
 
 "custom/backlight": {

--- a/config/waybar/configs/LEFT-WestWing-v2
+++ b/config/waybar/configs/LEFT-WestWing-v2
@@ -60,8 +60,7 @@
 "backlight/slider": {
 	"min": 0,
 	"max": 100,
-	"orientation": "vertical",
-	"device": "intel_backlight"
+	"orientation": "vertical"
 },
 
 }

--- a/config/waybar/configs/RIGHT-EastWing-v2
+++ b/config/waybar/configs/RIGHT-EastWing-v2
@@ -60,8 +60,7 @@
 "backlight/slider": {
 	"min": 0,
 	"max": 100,
-	"orientation": "vertical",
-	"device": "intel_backlight"
+	"orientation": "vertical"
 },
 
 }

--- a/config/waybar/configs/TOP-Camellia
+++ b/config/waybar/configs/TOP-Camellia
@@ -67,8 +67,7 @@
 "backlight/slider": {
 	"min": 0,
 	"max": 100,
-	"orientation": "horizontal",
-	"device": "intel_backlight"
+	"orientation": "horizontal"
 },
 
 "custom/backlight": {


### PR DESCRIPTION
## Description

Several bundled Waybar layouts hardcode `intel_backlight`. Those modules do not work on AMD laptops, where the display device is usually named `amdgpu_bl*`.

This removes the fixed device from the shared module and four slider layouts. Waybar already prefers a screen backlight when `device` is omitted, so the same configuration now works on Intel, AMD and other supported hardware.

No new dependency is required.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to documentation)
- [ ] **Technical debt**
- [ ] **Other**

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the commit guidelines.
- [ ] My change requires a documentation update.
- [ ] I want to add something to the Hyprland-Dots wiki.
- [ ] I have added automated tests.
- [x] I tested the affected Waybar configuration files locally.
- [x] Relevant validation passed.

## Screenshots

Not applicable.

## Additional context

Validated on an ASUS ProArt P16 with an AMD Radeon 890M. Its display backlight is `amdgpu_bl1`; Waybar selects it automatically when the device field is absent. All five changed configuration files pass Waybar parsing, and no `intel_backlight` device override remains under `config/waybar`.