### PR TITLE
Refresh.sh/DarkLight.sh: stop killing swaync with SIGUSR1

### DIFF
--- a/config/hypr/scripts/DarkLight.sh
+++ b/config/hypr/scripts/DarkLight.sh
@@ -141,8 +141,9 @@ done
 
 # Signal running processes to prepare for theme change.
 # Skip hiding waybar on startup (--no-restart) so it stays visible while colors regenerate.
+# swaync is excluded: SIGUSR1 kills it and makes its unit restart.
 if [ "$no_restart" -eq 0 ]; then
-    for pid in waybar rofi swaync ags swaybg; do
+    for pid in waybar rofi ags swaybg; do
         killall -SIGUSR1 "$pid"
     done
 fi
@@ -507,7 +508,9 @@ if [ "$no_restart" -eq 0 ]; then
     # waybar module on-click, so it lives in waybar.service's cgroup. Killing waybar makes
     # systemd tear down the whole unit, taking this script with it before Refresh.sh runs.
     # Refresh.sh restarts waybar detached from that cgroup instead.
-    for pid1 in rofi swaync ags swaybg; do
+    # swaync is excluded: Refresh.sh below reloads it in place and picks up the
+    # style.css written above. Killing it here would drop it out of its unit.
+    for pid1 in rofi ags swaybg; do
         killall "$pid1"
     done
     sleep 1

--- a/config/hypr/scripts/Refresh.sh
+++ b/config/hypr/scripts/Refresh.sh
@@ -20,8 +20,8 @@ file_exists() {
   fi
 }
 
-# Kill already running processes (exclude waybar to avoid double reloads)
-_ps=(rofi swaync ags)
+# Kill already running processes (exclude waybar and swaync to avoid double reloads)
+_ps=(rofi ags)
 for _prs in "${_ps[@]}"; do
   if pidof "${_prs}" >/dev/null; then
     pkill "${_prs}"
@@ -41,8 +41,8 @@ fi
 # quit quickshell & relaunch quickshell
 pkill qs && qs --log-rules "$QS_TEXTINPUT_LOG_RULE" &
 
-# some process to kill (exclude waybar to avoid restart loops)
-for pid in $(pidof rofi swaync ags swaybg); do
+# some process to kill (exclude waybar and swaync to avoid restart loops)
+for pid in $(pidof rofi ags swaybg); do
   kill -SIGUSR1 "$pid"
   sleep 0.1
 done
@@ -59,6 +59,19 @@ is_waybar_systemd() {
     enabled|static) return 0 ;;
   esac
   systemctl --user is-active --quiet waybar.service 2>/dev/null && return 0
+  return 1
+}
+
+# Same idea as is_waybar_systemd, for swaync.
+is_swaync_systemd() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  systemctl --user cat swaync.service >/dev/null 2>&1 || return 1
+  local enabled_state
+  enabled_state="$(systemctl --user is-enabled swaync.service 2>/dev/null || true)"
+  case "$enabled_state" in
+    enabled|static) return 0 ;;
+  esac
+  systemctl --user is-active --quiet swaync.service 2>/dev/null && return 0
   return 1
 }
 
@@ -117,12 +130,17 @@ restart_waybar() {
 restart_waybar
 
 # relaunch swaync
-sleep 0.3
-if ! pidof swaync >/dev/null 2>&1; then
-  swaync >/dev/null 2>&1 &
+if is_swaync_systemd; then
+  systemctl --user reload-or-restart swaync.service >/dev/null 2>&1 &
+else
+  sleep 0.3
+  if ! pidof swaync >/dev/null 2>&1; then
+    swaync >/dev/null 2>&1 &
+  fi
+  # reload swaync (asynchronous to prevent DBus timeout delays)
+  (swaync-client --reload-config >/dev/null 2>&1 &)
+  (swaync-client --reload-css >/dev/null 2>&1 &)
 fi
-# reload swaync (asynchronous to prevent DBus timeout delays)
-(swaync-client --reload-config >/dev/null 2>&1 &)
 
 # reload / restart nwg-dock-hyprland if running
 if pgrep -x "nwg-dock-hyprla" >/dev/null 2>&1 || pgrep -x "nwg-dock-hyprland" >/dev/null 2>&1 || pgrep -f "nwg-dock-hyprland" >/dev/null 2>&1; then


### PR DESCRIPTION
# Pull Request

## Description

swaync installs no handler for SIGUSR1, so `kill -SIGUSR1` terminates it with code=killed, status=10/USR1. SIGUSR1 is not among the signals `Restart=on-failure` treats as a clean exit, so swaync.service restarts on every Refresh.sh run, and a few runs in a row trip StartLimitBurst:

    swaync.service: Main process exited, code=killed, status=10/USR1
    swaync.service: Start request repeated too quickly.
    swaync.service: Failed with result 'start-limit-hit'.



This drops swaync from the three kill lists in Refresh.sh and DarkLight.sh and reloads it at the end of Refresh.sh instead. Where a swaync.service is actually in use, `systemctl --user reload-or-restart` is used; the check mirrors the existing `is_waybar_systemd()` in the same file, so installations that run swaync bare keep the current code path unchanged.

## Type of change
Changed files: scripts/Refresh.sh and scripts/DarkLight.sh.

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist


Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
