### PR TITLE
Fix default-app source order before keybinds

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -12,9 +12,6 @@ $scriptsDir = $HOME/.config/hypr/scripts
 $UserConfigs = $HOME/.config/hypr/UserConfigs
 $UserScripts = $HOME/.config/hypr/UserScripts
 
-# settings for User defaults apps - set your default terminal and file manager on this file
-source= $UserConfigs/01-UserDefaults.conf
-
 #### STANDARD ####
 # Common shortcuts
 #bindr = $mainMod, $mainMod_L, exec, pkill rofi || rofi -show drun -modi drun,filebrowser,run,window # Super Key to Launch rofi menu

--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -11,6 +11,7 @@ exec-once = $HOME/.config/hypr/initial-boot.sh
 $configs = $HOME/.config/hypr/configs # Default Configs directory path
 $UserConfigs = $HOME/.config/hypr/UserConfigs # User Configs directory path
 
+source= $UserConfigs/01-UserDefaults.conf # settings for User default apps
 source=$configs/Keybinds.conf # Pre-configured keybinds
 
 # Load defaults, then user additions/overrides
@@ -37,7 +38,6 @@ source= $UserConfigs/UserDecorations.conf # Decorations config file
 source= $UserConfigs/UserAnimations.conf # Animation config file
 source= $UserConfigs/UserKeybinds.conf # Put your own keybinds here
 source= $UserConfigs/UserSettings.conf # Main Hyprland Settings.
-source= $UserConfigs/01-UserDefaults.conf # settings for User defaults apps
 
 # nwg-displays
 source= $HOME/.config/hypr/monitors.conf


### PR DESCRIPTION
## Summary

- load `UserConfigs/01-UserDefaults.conf` before `configs/Keybinds.conf`
- remove the nested defaults source from `Keybinds.conf`
- remove the late duplicate defaults source from `hyprland.conf`

This ensures `$term`, `$files`, and other default-application variables are defined before keybind commands expand them, including after `hyprctl reload`.

## Validation

- applied the same ordering to a live Hyprland 0.56.2 session
- `hyprctl reload` completed without configuration errors
- verified there is one top-level defaults source and it precedes `Keybinds.conf`
- `git diff --check` passes

Fixes #120
